### PR TITLE
chore: fixed stakedRatio calculation

### DIFF
--- a/server/api/[version]/distribution.ts
+++ b/server/api/[version]/distribution.ts
@@ -21,7 +21,7 @@ export default defineCachedEventHandler(async () => {
     )
     .get()
 
-  const staked = (result?.totalStaked ?? 0) * 1e5
+  const staked = (result?.totalStaked ?? 0) / 1e5
 
   const { data: latestBlock, error: errorCurrentEpoch } = await getRpcClient().blockchain.getLatestBlock()
   if (errorCurrentEpoch)


### PR DESCRIPTION
# Before

https://validators-api-mainnet.nuxt.dev/api/v1/distribution

```json
{"staked":67458370100169600000,"circulating":12962153207.99921,"stakedRatio":5204256501.037162}
```

# After

```json
{
  "staked": 6745837010.01696,
  "circulating": 12962201045.21364,
  "stakedRatio": 0.520423729464364
}
```