### PR TITLE
ci: add Sync Matrix workflow for hourly API synchronization

### DIFF
--- a/.github/workflows/sync-matrix.yaml
+++ b/.github/workflows/sync-matrix.yaml
@@ -1,0 +1,26 @@
+name: Sync Matrix
+
+on:
+  schedule:
+    - cron: '0 * * * *' # Runs hourly
+  workflow_dispatch: # Allows manual triggering of the workflow
+
+jobs:
+  call-endpoints:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        endpoint:
+          # - https://validators-api-mainnet.nuxt.dev
+          # - https://validators-api-testnet.nuxt.dev
+          # - https://dev.validators-api-mainnet.nuxt.dev
+          - https://dev.validators-api-testnet.nuxt.dev
+    steps:
+      - name: Stream sync API
+        run: |
+          # --no-buffer (or -N) tells curl to flush each chunk as soon as it arrives,
+          # so can see Nitro stream lines in real time.
+          curl -fsS --no-buffer "${{ matrix.endpoint }}/api/v1/sync" || {
+            echo "Sync request failed for ${{ matrix.endpoint }}"
+            exit 1
+          }


### PR DESCRIPTION
GitHub Action with schedule only are triggered from `main`. Since we want to test our code, we merge this action separately. See: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule

As you can see we only target preview on testnet, so it should be safe for rest of environments