### PR TITLE
ci: update NuxtHub deployment workflows for mainnet and testnet

### DIFF
--- a/.github/workflows/nuxthub-validators-api-mainnet.yml
+++ b/.github/workflows/nuxthub-validators-api-mainnet.yml
@@ -3,7 +3,7 @@ on: push
 
 jobs:
   deploy:
-    name: "Deploy to NuxtHub"
+    name: Deploy to NuxtHub
     runs-on: ubuntu-latest
     environment:
       name: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
@@ -22,16 +22,22 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: 'pnpm'
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install
+        env:
+          NUXT_RPC_URL: ${{ secrets.NUXT_RPC_URL }}
+          NUXT_PUBLIC_NIMIQ_NETWORK: mainnet
 
       - name: Ensure NuxtHub module is installed
         run: pnpx nuxthub@latest ensure
 
       - name: Build application
         run: pnpm build
+        env:
+          NUXT_RPC_URL: ${{ secrets.NUXT_RPC_URL }}
+          NUXT_PUBLIC_NIMIQ_NETWORK: mainnet
 
       - name: Deploy to NuxtHub
         uses: nuxt-hub/action@v1

--- a/.github/workflows/nuxthub-validators-api-testnet.yml
+++ b/.github/workflows/nuxthub-validators-api-testnet.yml
@@ -3,7 +3,7 @@ on: push
 
 jobs:
   deploy:
-    name: "Deploy to NuxtHub"
+    name: Deploy to NuxtHub
     runs-on: ubuntu-latest
     environment:
       name: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
@@ -22,16 +22,22 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: 'pnpm'
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install
+        env:
+          NUXT_RPC_URL: ${{ secrets.NUXT_RPC_URL }}
+          NUXT_PUBLIC_NIMIQ_NETWORK: testnet
 
       - name: Ensure NuxtHub module is installed
         run: pnpx nuxthub@latest ensure
 
       - name: Build application
         run: pnpm build
+        env:
+          NUXT_RPC_URL: ${{ secrets.NUXT_RPC_URL }}
+          NUXT_PUBLIC_NIMIQ_NETWORK: testnet
 
       - name: Deploy to NuxtHub
         uses: nuxt-hub/action@v1


### PR DESCRIPTION
prod is broken because it cannot access node_url_rpc 🫰🫰