### PR TITLE
fix: add URL allowlist to RPC proxy to prevent SSRF

### DIFF
--- a/server/api/[version]/rpc-proxy.post.ts
+++ b/server/api/[version]/rpc-proxy.post.ts
@@ -4,6 +4,32 @@
  * Developer Center without the need for CORS.
  */
 
+// Allowlist of Nimiq RPC hosts to prevent SSRF attacks
+const ALLOWED_RPC_HOSTS = [
+  // Mainnet
+  'seed1.nimiq.com',
+  'seed2.nimiq.com',
+  'seed3.nimiq.com',
+  'seed4.nimiq.com',
+  // Testnet
+  'seed1.pos.nimiq-testnet.com',
+  'history1.pos.nimiq-testnet.com',
+  // Nimiq infrastructure
+  'rpc.nimiq.com',
+  'rpc.nimiq-testnet.com',
+  'orbital.history.nimiq.systems',
+]
+
+function isAllowedUrl(urlString: string): boolean {
+  try {
+    const url = new URL(urlString)
+    return ALLOWED_RPC_HOSTS.includes(url.hostname)
+  }
+  catch {
+    return false
+  }
+}
+
 export default defineEventHandler(async (event) => {
   const body = await readBody(event)
 
@@ -11,6 +37,9 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, message: 'Missing payload in request body' })
   if (!body.url)
     throw createError({ statusCode: 400, message: 'Missing url in request body' })
+
+  if (!isAllowedUrl(body.url))
+    throw createError({ statusCode: 403, message: 'URL not in allowed RPC hosts list' })
 
   try {
     const response = await fetch(body.url, {


### PR DESCRIPTION
## Summary
The `/api/v1/rpc-proxy` endpoint allowed arbitrary URLs, enabling SSRF attacks.

## Fix
Add allowlist of known Nimiq RPC hosts:
- Mainnet seeds (seed1-4.nimiq.com)
- Testnet seeds (seed1.pos.nimiq-testnet.com, history1.pos.nimiq-testnet.com)
- Nimiq infrastructure (rpc.nimiq.com, orbital.history.nimiq.systems)

Requests to non-allowed hosts now return 403.