### PR TITLE
docs: update deployment URLs for Workers migration

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,62 @@
+# Pages to Workers Migration Guide
+
+## Background
+
+Cloudflare Pages does NOT support scheduled tasks (cron jobs). This project requires hourly syncing, so we migrated to Cloudflare Workers.
+
+## Setting Up Redirects
+
+To maintain backwards compatibility, configure the old Pages deployments to redirect to Workers.
+
+### For Mainnet Pages Project
+
+Create `_redirects` file in the Pages project root:
+
+```
+/api/*  https://validators-api-main.workers.dev/api/:splat  301
+/*      https://validators-api-main.workers.dev/:splat       301
+```
+
+Deploy this file to `validators-api-mainnet` Pages project.
+
+### For Testnet Pages Project
+
+Create `_redirects` file in the Pages project root:
+
+```
+/api/*  https://validators-api-test.workers.dev/api/:splat  301
+/*      https://validators-api-test.workers.dev/:splat       301
+```
+
+Deploy this file to `validators-api-testnet` Pages project.
+
+### Alternative: Dashboard Configuration
+
+Go to Cloudflare Dashboard → Pages → [Project] → Rules → Redirects:
+
+**Mainnet:**
+
+- Source: `/*` → Destination: `https://validators-api-main.workers.dev/$1` (301)
+
+**Testnet:**
+
+- Source: `/*` → Destination: `https://validators-api-test.workers.dev/$1` (301)
+
+## Verification
+
+Test redirects work:
+
+```bash
+curl -I https://validators-api-mainnet.pages.dev/api/v1/status
+# Should return 301 redirect to validators-api-main.workers.dev
+
+curl -I https://validators-api-testnet.pages.dev/api/v1/status
+# Should return 301 redirect to validators-api-test.workers.dev
+```
+
+## Timeline
+
+1. Verify Workers fully operational
+2. Deploy redirects to Pages projects
+3. Monitor for 1-2 weeks
+4. (Optional) Deprecate .pages.dev URLs and add custom domain

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 <h2 align="center">Dashboards</h2>
 
 <p align="center">
-<a href="https://validators-api-mainnet.pages.dev" target="_blank">Mainnet</a>&nbsp; &nbsp; &nbsp;
-<a href="https://validators-api-testnet.pages.dev" target="_blank">Testnet</a>
+<a href="https://validators-api-main.workers.dev" target="_blank">Mainnet</a>&nbsp; &nbsp; &nbsp;
+<a href="https://validators-api-test.workers.dev" target="_blank">Testnet</a>
 </p>
 
 <br />
@@ -43,7 +43,7 @@ If you operate a staking pool and want to be displayed in the Nimiq Wallet, foll
 3. Review the [Description Guidelines](#recommendations-for-your-validator-description).
 4. Learn about the [JSON Schema](#validator-json-schema).
 5. Submit a PR to this repository. A Nimiq team member will review your submission within 3 days.
-6. Once the PR is submitted, check that the [API endpoint](https://validators-api-mainnet.pages.dev/api/v1/validators) returns your information. This process may take a few minutes.
+6. Once the PR is submitted, check that the [API endpoint](https://validators-api-main.workers.dev/api/v1/validators) returns your information. This process may take a few minutes.
 
 > [!WARNING]
 > Nimiq reserves the right to make minor adjustments to the content submitted by validator owners if necessary.
@@ -113,13 +113,13 @@ The VTS is displayed in the Nimiq Wallet, allowing stakers to compare validators
 The Validators API provides endpoints to retrieve validator information for integration with tools, dashboards, and other applications.
 | Endpoint | Description |
 | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| [/api/v1/validators](https://validators-api-mainnet.pages.dev/api/v1/validators) | Retrieves the validator list. See [query params](./server/utils/schemas.ts#L54) |
-| [/api/v1/validators/:validator_address](https://validators-api-mainnet.pages.dev/api/v1/validators/NQ7700000000000000000000000000000001) | Retrieves the validator information |
-| [/api/v1/supply](https://validators-api-mainnet.pages.dev/api/v1/supply) | Retrieves supply status |
+| [/api/v1/validators](https://validators-api-main.workers.dev/api/v1/validators) | Retrieves the validator list. See [query params](./server/utils/schemas.ts#L54) |
+| [/api/v1/validators/:validator_address](https://validators-api-main.workers.dev/api/v1/validators/NQ7700000000000000000000000000000001) | Retrieves the validator information |
+| [/api/v1/supply](https://validators-api-main.workers.dev/api/v1/supply) | Retrieves supply status |
 
 ## Validators Dashboard
 
-The Validators Dashboard is a simple Nuxt application that displays all validators along with their scores. You can access the dashboard here: https://validators-api-mainnet.pages.dev/
+The Validators Dashboard is a simple Nuxt application that displays all validators along with their scores. You can access the dashboard here: https://validators-api-main.workers.dev/
 
 > [!TIP]
 > Check also the [deployment](#deployment) section to learn how to access to the `testnet` and `preview` environments.
@@ -215,13 +215,24 @@ Where `env`: `preview`, `testnet`, or `testnet-preview` (omit for mainnet produc
 
 **Environments** (configured in `wrangler.json`):
 
-| Environment       | Dashboard URL                                                                  | Trigger            |
-| ----------------- | ------------------------------------------------------------------------------ | ------------------ |
-| `production`      | [Validators API Mainnet](https://validators-api-mainnet.pages.dev)             | Push to `main`     |
-| `preview`         | [Validators API Mainnet Preview](https://dev.validators-api-mainnet.pages.dev) | Push to any branch |
-| `testnet`         | [Validators API Testnet](https://validators-api-testnet.pages.dev)             | Push to `main`     |
-| `testnet-preview` | [Validators API Testnet Preview](https://dev.validators-api-testnet.pages.dev) | Push to any branch |
+| Environment       | Dashboard URL                                                             | Trigger                                |
+| ----------------- | ------------------------------------------------------------------------- | -------------------------------------- |
+| `production`      | [Validators API Mainnet](https://validators-api-main.workers.dev)         | Manual `wrangler deploy`               |
+| `preview`         | [Validators API Mainnet Preview](https://validators-api-main.workers.dev) | Manual deployment                      |
+| `testnet`         | [Validators API Testnet](https://validators-api-test.workers.dev)         | Manual `wrangler deploy --env testnet` |
+| `testnet-preview` | [Validators API Testnet Preview](https://validators-api-test.workers.dev) | Manual deployment                      |
 
 Each environment has its own D1 database, KV cache, and R2 blob. Sync runs hourly via Cloudflare cron triggers (see `server/tasks/sync/`).
+
+### Deployment Migration
+
+Migrated from Cloudflare Pages to Workers for cron job support.
+
+**Old URLs (redirect to Workers):**
+
+- `validators-api-mainnet.pages.dev` → `validators-api-main.workers.dev`
+- `validators-api-testnet.pages.dev` → `validators-api-test.workers.dev`
+
+Setup redirects per [MIGRATION.md](./MIGRATION.md).
 
 **Write operations to `main` are restricted**, only via PR.


### PR DESCRIPTION
## Summary
Pages → Workers migration (Pages lacks cron support needed for hourly syncs)

## Changes
- README: .pages.dev → .workers.dev URLs
- Add MIGRATION.md with redirect instructions

## Post-Merge Actions Required

### 1. Set up redirects on old Pages deployments

**Option A - Dashboard (recommended):**
Cloudflare Dashboard → Pages → [Project] → Rules → Redirects:
- Mainnet: `/*` → `https://validators-api-main.workers.dev/$1` (301)
- Testnet: `/*` → `https://validators-api-test.workers.dev/$1` (301)

**Option B - _redirects file:**
Deploy _redirects file to each Pages project (see MIGRATION.md)

### 2. Verify redirects work
```bash
curl -I https://validators-api-mainnet.pages.dev/api/v1/status
curl -I https://validators-api-testnet.pages.dev/api/v1/status
```
Both should return 301 → .workers.dev

See MIGRATION.md for full details.