### PR TITLE
fix: data sync + enable observability

### DIFF
--- a/server/assets/validators
+++ b/server/assets/validators
@@ -1,0 +1,1 @@
+../../public/validators

--- a/server/plugins/setup-database.ts
+++ b/server/plugins/setup-database.ts
@@ -10,7 +10,7 @@ export default defineNitroPlugin(async () => {
     if (gitBranch !== 'dev')
       return
 
-    const [ok, error, validators] = await importValidators('filesystem', { nimiqNetwork, gitBranch })
+    const [ok, error, validators] = await importValidatorsBundled(nimiqNetwork)
     if (!ok)
       throw new Error(`Error importing validators: ${error}`)
     consola.success(`${validators.length} validators imported successfully`)

--- a/server/tasks/cron/sync.ts
+++ b/server/tasks/cron/sync.ts
@@ -52,7 +52,10 @@ export default defineTask({
       for (const taskName of TASKS) {
         consola.info(`[cron:sync] running ${taskName}`)
         const res = await runTask(taskName, { payload: event.payload ?? {}, context: event.context ?? {} })
-        results[taskName] = (res as any)?.result ?? res
+        const result = (res as any)?.result ?? res
+        results[taskName] = result
+        if (result?.success === false)
+          throw new Error(`${taskName} failed: ${result.error || 'unknown'}`)
       }
 
       if (cronRunId) {

--- a/server/tasks/sync/epochs.ts
+++ b/server/tasks/sync/epochs.ts
@@ -39,7 +39,7 @@ export default defineTask({
           break
 
         const missingEpoch = missingEpochs.at(0)!
-        const [activityOk, activityError, epochActivity] = await fetchActivity(missingEpoch)
+        const [activityOk, activityError, epochActivity] = await fetchActivity(missingEpoch, { network: config.public.nimiqNetwork, maxBatchSize: import.meta.dev ? 120 : 6 })
         if (!activityOk || !epochActivity) {
           const error = new Error(activityError || 'Unable to fetch activity')
           await sendSyncFailureNotification('missing-epoch', error)

--- a/server/tasks/sync/snapshot.ts
+++ b/server/tasks/sync/snapshot.ts
@@ -16,13 +16,11 @@ export default defineTask({
         throw new Error('No Albatross RPC Node URL')
       initRpcClient({ url: rpcUrl })
 
-      const { nimiqNetwork, gitBranch } = config.public
+      const { nimiqNetwork } = config.public
 
-      const [importSuccess, errorImport, importData] = import.meta.dev
-        ? await importValidators('filesystem', { nimiqNetwork, gitBranch })
-        : await importValidatorsBundled(nimiqNetwork)
+      const [importSuccess, errorImport, importData] = await importValidatorsBundled(nimiqNetwork)
       if (!importSuccess || !importData) {
-        const error = new Error(errorImport || 'Unable to import from GitHub')
+        const error = new Error(errorImport || 'Unable to import validators')
         await sendSyncFailureNotification('snapshot', error)
         return { result: { success: false, error: errorImport } }
       }

--- a/server/utils/json-files.ts
+++ b/server/utils/json-files.ts
@@ -2,133 +2,41 @@ import type { Result } from 'nimiq-validator-trustscore/types'
 import type { ValidatorJSON } from './schemas'
 import { readdir, readFile } from 'node:fs/promises'
 import { extname } from 'node:path'
-import process from 'node:process'
-import { consola } from 'consola'
-import { $fetch } from 'ofetch'
 import { join } from 'pathe'
 import { validatorSchema } from './schemas'
+
 /**
  * Import validators from a folder containing .json files.
- *
- * This function is expected to be used when initializing the database with validators, so it will throw
- * an error if the files are not valid and the program should stop.
+ * Used by the validation script to check files on disk.
  */
-export async function importValidatorsFromFiles(folderPath: string): Result<any[]> {
+export async function importValidators(nimiqNetwork: string): Result<ValidatorJSON[]> {
+  if (!nimiqNetwork)
+    return [false, 'Nimiq network is required', undefined]
+
+  const folderPath = `public/validators/${nimiqNetwork}`
   const allFiles = await readdir(folderPath)
   const files = allFiles
     .filter(f => extname(f) === '.json')
     .filter(f => !f.endsWith('.example.json'))
 
-  const rawValidators: any[] = []
+  const validators: ValidatorJSON[] = []
   for (const file of files) {
     const filePath = join(folderPath, file)
     const fileContent = await readFile(filePath, 'utf8')
 
+    let raw: unknown
     try {
-      rawValidators.push(JSON.parse(fileContent))
+      raw = JSON.parse(fileContent)
     }
     catch (error) {
       return [false, `Invalid JSON in file: ${file}. Error: ${error}`, undefined]
     }
+
+    const parsed = validatorSchema.safeParse(raw)
+    if (!parsed.success)
+      return [false, `Invalid validator ${file}: ${parsed.error}`, undefined]
+    validators.push(parsed.data)
   }
-  return [true, undefined, rawValidators]
-}
-
-/**
- * Import validators from GitHub using the official GitHub REST API.
- */
-async function importValidatorsFromGitHub(path: string, { gitBranch }: Pick<ImportValidatorsFromFilesOptions, 'gitBranch'>): Result<any[]> {
-  // Default to main branch if not specified
-  const branch = gitBranch || 'main'
-
-  // Check if running in a fork PR (GitHub Actions sets GITHUB_HEAD_REPOSITORY)
-  const headRepo = process.env.GITHUB_HEAD_REPOSITORY // format: "owner/repo"
-  const baseRepo = process.env.GITHUB_REPOSITORY || 'nimiq/validators-api'
-
-  // Use head repo if it's different from base (fork PR scenario)
-  const [owner, repo] = (headRepo && headRepo !== baseRepo ? headRepo : baseRepo).split('/')
-
-  const apiUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${branch}`
-
-  // 1. List directory contents
-  let listing: Array<{
-    name: string
-    path: string
-    type: 'file' | 'dir'
-    download_url: string
-  }>
-
-  const headers: HeadersInit = { 'User-Agent': 'request' }
-  try {
-    listing = await $fetch(apiUrl, { headers })
-  }
-  catch (e) {
-    consola.warn(`Error listing validators folder on GitHub: ${e}`)
-    return [false, `Could not list validators on GitHub ${apiUrl} | ${e}`, undefined]
-  }
-
-  // 2. Filter only .json files (skip .example.json)
-  const jsonFiles = listing.filter(file =>
-    file.type === 'file'
-    && file.name.endsWith('.json')
-    && !file.name.endsWith('.example.json'),
-  )
-
-  // 3. Fetch each file’s raw contents
-  const rawContents = await Promise.all(jsonFiles.map(async (file) => {
-    try {
-      return await $fetch<string>(file.download_url, { headers })
-    }
-    catch (e) {
-      consola.warn(`Failed to download ${file.path}: ${e}`)
-      return [false, `Failed to download ${file.path}: ${e}`, undefined]
-    }
-  }))
-
-  // 4. Parse JSON and return
-  const parsed = rawContents.filter((c): c is string => Boolean(c)).map(c => JSON.parse(c!))
-
-  return [true, undefined, parsed]
-}
-
-interface ImportValidatorsFromFilesOptions {
-  nimiqNetwork?: string
-  gitBranch?: string
-  shouldStore?: boolean
-}
-
-/**
- * Import validators from either the filesystem or GitHub, then validate & store.
- */
-export async function importValidators(source: 'filesystem' | 'github', options: ImportValidatorsFromFilesOptions = {}): Result<ValidatorJSON[]> {
-  const { nimiqNetwork, shouldStore = true, gitBranch } = options
-  if (!nimiqNetwork)
-    return [false, 'Nimiq network is required', undefined]
-
-  const path = `public/validators/${nimiqNetwork}`
-
-  const [ok, readError, data] = source === 'filesystem'
-    ? await importValidatorsFromFiles(path)
-    : await importValidatorsFromGitHub(path, { gitBranch })
-
-  if (!ok)
-    return [false, readError, undefined]
-
-  const validators: ValidatorJSON[] = []
-  for (const validator of data) {
-    const { data, success, error } = validatorSchema.safeParse(validator)
-    if (!success)
-      return [false, `Invalid validator ${validator.name}(${validator.address}) data: ${error || 'Unknown error'}. ${JSON.stringify({ path, gitBranch, source })}`, undefined]
-    validators.push(data)
-  }
-
-  if (!shouldStore)
-    return [true, undefined, validators]
-
-  const results = await Promise.allSettled(validators.map(v => storeValidator(v.address, v, { upsert: true })))
-  const failures = results.filter(r => r.status === 'rejected')
-  if (failures.length > 0)
-    return [false, `Errors importing validators: ${failures.map((f: any) => f.reason).join(', ')}`, undefined]
 
   return [true, undefined, validators]
 }

--- a/server/utils/validators-bundle.ts
+++ b/server/utils/validators-bundle.ts
@@ -7,46 +7,31 @@ interface ImportValidatorsBundledOptions {
   shouldStore?: boolean
 }
 
-function normalizePath(value: string) {
-  return value.replace(/\\/g, '/')
-}
-
-function extractNetworkFromPath(path: string) {
-  const normalized = normalizePath(path)
-  const match = normalized.match(/(?:^|\/)public\/validators\/([^/]+)\/[^/]+\.json$/)
-  return match?.[1]
-}
-
 export async function importValidatorsBundled(nimiqNetwork?: string, options: ImportValidatorsBundledOptions = {}): Result<ValidatorJSON[]> {
   if (!nimiqNetwork)
     return [false, 'Nimiq network is required', undefined]
 
   const { shouldStore = true } = options
-  const modules = import.meta.glob('../../public/validators/*/*.json', { eager: true, import: 'default' })
+  const storage = useStorage('assets:server:validators')
+  const keys = await storage.getKeys(`${nimiqNetwork}`)
 
   const validators: ValidatorJSON[] = []
-  for (const [path, mod] of Object.entries(modules)) {
-    if (path.endsWith('.example.json'))
+  for (const key of keys) {
+    if (!key.endsWith('.json') || key.endsWith('.example.json'))
       continue
 
-    const network = extractNetworkFromPath(path)
-    if (!network || network !== nimiqNetwork)
-      continue
-
-    const data = (mod as any)?.default ?? mod
+    const data = await storage.getItem(key)
     const parsed = validatorSchema.safeParse(data)
-    if (!parsed.success) {
-      return [false, `Invalid validator data at ${path}: ${parsed.error}`, undefined]
-    }
+    if (!parsed.success)
+      return [false, `Invalid validator data at ${key}: ${parsed.error}`, undefined]
     validators.push(parsed.data)
   }
 
   if (!shouldStore)
     return [true, undefined, validators]
 
-  if (validators.length === 0) {
+  if (validators.length === 0)
     return [false, `No bundled validators found for network: ${nimiqNetwork}`, undefined]
-  }
 
   const results = await Promise.allSettled(validators.map(v => storeValidator(v.address, v, { upsert: true })))
   const failures = results.filter(r => r.status === 'rejected')

--- a/wrangler.json
+++ b/wrangler.json
@@ -9,7 +9,7 @@
   "observability": {
     "enabled": true,
     "logs": {
-      "enabled": false,
+      "enabled": true,
       "invocation_logs": true
     }
   },
@@ -24,6 +24,7 @@
       "main": "dist/server/index.mjs",
       "assets": { "directory": "dist/public" },
       "compatibility_flags": ["nodejs_compat"],
+      "observability": { "enabled": true, "logs": { "enabled": true, "invocation_logs": true } },
       "triggers": { "crons": ["0 */12 * * *"] },
       "vars": { "NUXT_PUBLIC_NIMIQ_NETWORK": "main-albatross" },
       "d1_databases": [{ "binding": "DB", "database_id": "dd9fa8b7-f5a1-48ab-b0af-d93d1092b89a", "database_name": "validators-api-mainnet-preview" }],
@@ -35,6 +36,7 @@
       "main": "dist/server/index.mjs",
       "assets": { "directory": "dist/public" },
       "compatibility_flags": ["nodejs_compat"],
+      "observability": { "enabled": true, "logs": { "enabled": true, "invocation_logs": true } },
       "triggers": { "crons": ["0 */12 * * *"] },
       "vars": { "NUXT_PUBLIC_NIMIQ_NETWORK": "test-albatross" },
       "d1_databases": [{ "binding": "DB", "database_id": "de14e353-5028-4e52-a383-a9cc200d960d", "database_name": "validators-api-testnet" }],
@@ -46,6 +48,7 @@
       "main": "dist/server/index.mjs",
       "assets": { "directory": "dist/public" },
       "compatibility_flags": ["nodejs_compat"],
+      "observability": { "enabled": true, "logs": { "enabled": true, "invocation_logs": true } },
       "triggers": { "crons": ["0 */12 * * *"] },
       "vars": { "NUXT_PUBLIC_NIMIQ_NETWORK": "test-albatross" },
       "d1_databases": [{ "binding": "DB", "database_id": "da6931b2-6d06-4598-911b-fba1fa19efd2", "database_name": "validators-api-testnet-preview" }],


### PR DESCRIPTION
## Summary
- Cron reported "success" even when sync tasks failed (returned `{ success: false }` instead of throwing)
- `sync:epochs` started 120 concurrent fetch requests, exceeding Workers ~6 connection limit
- `import.meta.glob` in `validators-bundle.ts` wasn't compiled for Workers runtime
- Observability logs were disabled

## Changes
- **cron:sync**: check task result and throw on `success === false`
- **fetcher**: configurable `maxBatchSize` option, epochs task passes 6 in prod
- **validators-bundle**: replace `import.meta.glob` with `useStorage('assets:server:validators')` via symlinked `server/assets/`
- **wrangler.json**: enable logs in all envs