### PR TITLE
feat: redesign validator detail with 3 layouts

### DIFF
--- a/app/components/validator/LayoutDashboard.vue
+++ b/app/components/validator/LayoutDashboard.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import type { FetchedValidatorDetails } from '~~/server/utils/validators'
+import { CurveType } from 'vue-chrts'
+
+const props = defineProps<{ validator: FetchedValidatorDetails }>()
+const validatorRef = computed(() => props.validator)
+const { scoreTrendData, balanceData, activityData, feeDisplay, payoutDisplay, currentStakers, donutScoreData } = useValidatorCharts(validatorRef)
+
+const scoreCategories = { total: { name: 'Score', color: 'var(--nq-green)' } }
+const balanceCategories = { balance: { name: 'Balance (NIM)', color: 'var(--nq-gold)' } }
+const activityCategories = { rewarded: { name: 'Rewarded', color: 'var(--nq-green-400)' }, missed: { name: 'Missed', color: 'var(--nq-red-400)' } }
+const donutCategories = { 0: { name: 'Availability', color: 'var(--nq-blue)' }, 1: { name: 'Dominance', color: 'var(--nq-purple)' }, 2: { name: 'Reliability', color: 'var(--nq-orange)' } }
+</script>
+
+<template>
+  <div flex="~ col" f-mt-md>
+    <!-- Stats row -->
+    <div grid="~ cols-5 md:cols-3 sm:cols-2" gap-16>
+      <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md>
+        <span nq-label text="11 neutral-800">Fee</span>
+        <p text-24 font-bold text-orange lh-none mt-4>
+          {{ feeDisplay }}
+        </p>
+      </div>
+      <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md>
+        <span nq-label text="11 neutral-800">Payout</span>
+        <p text-24 font-bold text-blue lh-none mt-4>
+          {{ payoutDisplay }}
+        </p>
+      </div>
+      <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md>
+        <span nq-label text="11 neutral-800">Balance</span>
+        <p text-24 font-bold text-gold lh-none mt-4>
+          {{ formatLunaAsNim(validator.activity?.at(-1)?.balance ?? 0) }} NIM
+        </p>
+      </div>
+      <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md>
+        <span nq-label text="11 neutral-800">Stakers</span>
+        <p text-24 font-bold text-blue lh-none mt-4>
+          {{ largeNumberFormatter.format(currentStakers) }}
+        </p>
+      </div>
+      <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md flex="~ items-center gap-12">
+        <div>
+          <span nq-label text="11 neutral-800">Score</span>
+          <p text-24 font-bold text-green lh-none mt-4>
+            {{ Math.round((validator.score?.total ?? 0) * 100) }}
+          </p>
+        </div>
+        <ScorePie size-40 text-14 :score="validator.score?.total || 0" />
+      </div>
+    </div>
+
+    <!-- Charts row 1: Donut + Score trend -->
+    <div grid="~ cols-2 sm:cols-1" gap-16 f-mt-md>
+      <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md>
+        <span nq-label text="11 neutral-800" mb-8 block>Sub-Scores</span>
+        <DonutChart
+          :data="donutScoreData" :radius="80" :arc-width="16" :pad-angle="0.03"
+          :categories="donutCategories" hide-legend
+        />
+        <div flex="~ justify-center gap-16" mt-12>
+          <ScorePies v-if="validator.score" v-bind="validator.score" text-20 />
+        </div>
+      </div>
+      <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md>
+        <span nq-label text="11 neutral-800" mb-8 block>Score Trend</span>
+        <AreaChart
+          :data="scoreTrendData" :height="200" :categories="scoreCategories"
+          :x-formatter="(t: number) => `E${t}`" :y-formatter="(t: number) => `${Math.round(t * 100)}`"
+          :y-domain="[0, 1]" hide-legend :curve-type="CurveType.MonotoneX"
+        />
+      </div>
+    </div>
+
+    <!-- Charts row 2: Activity + Balance -->
+    <div grid="~ cols-2 sm:cols-1" gap-16 f-mt-md>
+      <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md>
+        <span nq-label text="11 neutral-800" mb-8 block>Activity (Rewarded / Missed)</span>
+        <BarChart
+          :data="activityData" :height="200" :categories="activityCategories"
+          :y-axis="['rewarded', 'missed']" stacked hide-legend
+          :x-formatter="(t: number) => `E${t}`"
+        />
+      </div>
+      <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md>
+        <span nq-label text="11 neutral-800" mb-8 block>Balance</span>
+        <LineChart
+          :data="balanceData" :height="200" :categories="balanceCategories"
+          :x-formatter="(t: number) => `E${t}`" :y-formatter="(t: number) => formatLunaAsNim(t * 1e5)"
+          hide-legend :curve-type="CurveType.MonotoneX"
+        />
+      </div>
+    </div>
+
+    <!-- Batches -->
+    <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md f-mt-md>
+      <span nq-label text="11 neutral-800" mb-12 block>Epoch Batches</span>
+      <Batches :activity="validator.activity" />
+    </div>
+  </div>
+</template>

--- a/app/components/validator/LayoutDeepDive.vue
+++ b/app/components/validator/LayoutDeepDive.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import type { FetchedValidatorDetails } from '~~/server/utils/validators'
+import { CurveType } from 'vue-chrts'
+
+const props = defineProps<{ validator: FetchedValidatorDetails }>()
+const validatorRef = computed(() => props.validator)
+const { scoreTrendAllData, stakersData, activityStats, feeDisplay, payoutDisplay } = useValidatorCharts(validatorRef)
+
+const allScoreCategories = {
+  total: { name: 'Total', color: 'var(--nq-green)' },
+  availability: { name: 'Availability', color: 'var(--nq-blue)' },
+  dominance: { name: 'Dominance', color: 'var(--nq-purple)' },
+  reliability: { name: 'Reliability', color: 'var(--nq-orange)' },
+}
+const stakersCategories = { stakers: { name: 'Stakers', color: 'var(--nq-blue)' } }
+
+// Combined balance + score data for DualChart
+const dualChartData = computed(() => {
+  if (!props.validator?.activity || !props.validator?.scores)
+    return []
+  const scoreMap = new Map(props.validator.scores.map(s => [s.epochNumber, s.total]))
+  return props.validator.activity.map(a => ({
+    epoch: a.epochNumber,
+    balance: a.balance / 1e5,
+    score: scoreMap.get(a.epochNumber) ?? 0,
+  }))
+})
+const dualBarCategories = { balance: { name: 'Balance (NIM)', color: 'var(--nq-gold)' } }
+const dualLineCategories = { score: { name: 'Score', color: 'var(--nq-green)' } }
+</script>
+
+<template>
+  <div flex="~ col" f-mt-md>
+    <!-- Hero: Score -->
+    <div flex="~ col items-center" bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md>
+      <span nq-label text="11 neutral-800">Current Score</span>
+      <ScorePie size-128 text-40 :score="validator.score?.total || 0" mt-16 />
+      <span text-14 text-neutral-700 mt-8>Epoch {{ validator.score?.epochNumber }}</span>
+      <ScorePies v-if="validator.score" v-bind="validator.score" text-28 mt-24 />
+    </div>
+
+    <!-- Score trends: 4 overlapping areas -->
+    <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md f-mt-md>
+      <span nq-label text="11 neutral-800" mb-8 block>Score Trends</span>
+      <AreaChart
+        :data="scoreTrendAllData" :height="280" :categories="allScoreCategories"
+        :x-formatter="(t: number) => `E${t}`" :y-formatter="(t: number) => `${Math.round(t * 100)}`"
+        :y-domain="[0, 1]" :curve-type="CurveType.MonotoneX"
+      />
+    </div>
+
+    <!-- Balance vs Score: DualChart -->
+    <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md f-mt-md>
+      <span nq-label text="11 neutral-800" mb-8 block>Balance vs Score</span>
+      <DualChart
+        :data="dualChartData" :height="240"
+        :bar-categories="dualBarCategories" :line-categories="dualLineCategories"
+        :bar-y-axis="['balance']" :line-y-axis="['score']"
+        :x-formatter="(t: number) => `E${t}`"
+      />
+    </div>
+
+    <!-- Two-col: Stakers + Activity stats & Batches -->
+    <div grid="~ cols-2 sm:cols-1" gap-16 f-mt-md>
+      <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md>
+        <span nq-label text="11 neutral-800" mb-8 block>Stakers</span>
+        <LineChart
+          :data="stakersData" :height="200" :categories="stakersCategories"
+          :x-formatter="(t: number) => `E${t}`" hide-legend :curve-type="CurveType.MonotoneX"
+        />
+      </div>
+      <div flex="~ col gap-16">
+        <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md>
+          <span nq-label text="11 neutral-800" mb-12 block>Activity Stats</span>
+          <div grid="~ cols-3" gap-8>
+            <Stat>
+              <template #value>
+                {{ largeNumberFormatter.format(activityStats.rewarded) }}
+              </template>
+              <template #description>
+                Rewarded
+              </template>
+            </Stat>
+            <Stat>
+              <template #value>
+                {{ largeNumberFormatter.format(activityStats.missed) }}
+              </template>
+              <template #description>
+                Missed
+              </template>
+            </Stat>
+            <Stat>
+              <template #value>
+                {{ percentageFormatter.format(activityStats.missRate) }}
+              </template>
+              <template #description>
+                Miss Rate
+              </template>
+            </Stat>
+          </div>
+        </div>
+        <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md>
+          <span nq-label text="11 neutral-800" mb-12 block>Batches</span>
+          <Batches :activity="validator.activity" />
+        </div>
+      </div>
+    </div>
+
+    <!-- Footer: Validator info -->
+    <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md f-mt-md flex="~ gap-24 wrap">
+      <div>
+        <span nq-label text="11 neutral-800">Fee</span>
+        <p text-18 font-semibold mt-4>
+          {{ feeDisplay }}
+        </p>
+      </div>
+      <div>
+        <span nq-label text="11 neutral-800">Payout</span>
+        <p text-18 font-semibold mt-4>
+          {{ payoutDisplay }}
+        </p>
+      </div>
+      <NuxtLink v-if="validator.website" :to="validator.website" target="_blank" nq-pill-sm nq-arrow nq-pill-tertiary self-center>
+        {{ validator.website?.replace(/https?:\/\//, '') }}
+      </NuxtLink>
+      <p v-if="validator.description" text="14 neutral-700" flex-1>
+        {{ validator.description }}
+      </p>
+    </div>
+  </div>
+</template>

--- a/app/components/validator/LayoutProfile.vue
+++ b/app/components/validator/LayoutProfile.vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+import type { FetchedValidatorDetails } from '~~/server/utils/validators'
+import { CurveType } from 'vue-chrts'
+
+const props = defineProps<{ validator: FetchedValidatorDetails }>()
+const validatorRef = computed(() => props.validator)
+const { scoreTrendData, balanceData, stakersData, activityStats, feeDisplay, payoutDisplay, currentBalance, currentStakers } = useValidatorCharts(validatorRef)
+
+const scoreCategories = { total: { name: 'Score', color: 'var(--nq-green)' } }
+const balanceCategories = { balance: { name: 'Balance (NIM)', color: 'var(--nq-gold)' } }
+const stakersCategories = { stakers: { name: 'Stakers', color: 'var(--nq-blue)' } }
+</script>
+
+<template>
+  <div flex="~ col" f-mt-md>
+    <!-- Profile card -->
+    <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md flex="~ gap-24 items-center">
+      <Identicon v-bind="validator" size-80 shrink-0 object-contain />
+      <div flex="~ col gap-8" flex-1>
+        <h2 text-32 font-bold lh-none m-0>
+          {{ validator.name }}
+        </h2>
+        <Copyable :content="validator.address" text-14 />
+        <p v-if="validator.description" text="14 neutral-700" mt-4 mb-0>
+          {{ validator.description }}
+        </p>
+        <div flex="~ gap-8 wrap" mt-8>
+          <span v-if="validator.isMaintainedByNimiq" nq-pill-sm bg-green-400 text-green-1100 flex="~ items-center gap-4">
+            <div aria-hidden i-nimiq:verified-filled />
+            Maintained by Nimiq
+          </span>
+          <span nq-pill-sm nq-pill-tertiary>Fee: {{ feeDisplay }}</span>
+          <span nq-pill-sm nq-pill-tertiary>Payout: {{ payoutDisplay }}</span>
+          <NuxtLink v-if="validator.website" :to="validator.website" target="_blank" nq-pill-sm nq-arrow nq-pill-tertiary>
+            {{ validator.website?.replace(/https?:\/\//, '') }}
+          </NuxtLink>
+        </div>
+      </div>
+    </div>
+
+    <!-- Two-column layout -->
+    <div grid="~ cols-[3fr_2fr] sm:cols-1" gap-16 f-mt-md>
+      <!-- Left 60% -->
+      <div flex="~ col gap-16">
+        <!-- Score card -->
+        <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md flex="~ items-center gap-24">
+          <ScorePie size-96 text-32 :score="validator.score?.total || 0" />
+          <ScorePies v-if="validator.score" v-bind="validator.score" text-24 />
+        </div>
+
+        <!-- Score trend -->
+        <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md>
+          <span nq-label text="11 neutral-800" mb-8 block>Score Trend</span>
+          <AreaChart
+            :data="scoreTrendData" :height="200" :categories="scoreCategories"
+            :x-formatter="(t: number) => `E${t}`" :y-formatter="(t: number) => `${Math.round(t * 100)}`"
+            :y-domain="[0, 1]" hide-legend :curve-type="CurveType.MonotoneX"
+          />
+        </div>
+
+        <!-- Batches -->
+        <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md>
+          <span nq-label text="11 neutral-800" mb-12 block>Epoch Batches</span>
+          <Batches :activity="validator.activity" />
+        </div>
+      </div>
+
+      <!-- Right 40% -->
+      <div flex="~ col gap-16">
+        <!-- Balance card -->
+        <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md>
+          <span nq-label text="11 neutral-800">Balance</span>
+          <p text-36 font-bold text-gold lh-none mt-8 mb-0>
+            {{ nimFormatter.format(currentBalance) }} <span text-18 font-normal>NIM</span>
+          </p>
+        </div>
+
+        <!-- Stakers card -->
+        <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md>
+          <span nq-label text="11 neutral-800">Stakers</span>
+          <p text-36 font-bold text-blue lh-none mt-8 mb-0>
+            {{ largeNumberFormatter.format(currentStakers) }}
+          </p>
+        </div>
+
+        <!-- Balance chart -->
+        <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md>
+          <LineChart
+            :data="balanceData" :height="140" :categories="balanceCategories"
+            :x-formatter="(t: number) => `E${t}`" :y-formatter="(t: number) => formatLunaAsNim(t * 1e5)"
+            hide-legend :curve-type="CurveType.MonotoneX"
+          />
+        </div>
+
+        <!-- Stakers chart -->
+        <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md>
+          <LineChart
+            :data="stakersData" :height="140" :categories="stakersCategories"
+            :x-formatter="(t: number) => `E${t}`" hide-legend :curve-type="CurveType.MonotoneX"
+          />
+        </div>
+
+        <!-- Activity stats -->
+        <div bg-neutral-0 outline="~ 1.5 neutral/6" rounded-8 shadow f-p-md>
+          <span nq-label text="11 neutral-800" mb-12 block>Activity</span>
+          <div flex="~ col gap-12">
+            <div flex="~ justify-between">
+              <span text-14 text-neutral-700>Rewarded</span>
+              <span text-14 font-semibold text-green>{{ largeNumberFormatter.format(activityStats.rewarded) }}</span>
+            </div>
+            <div flex="~ justify-between">
+              <span text-14 text-neutral-700>Missed</span>
+              <span text-14 font-semibold text-red>{{ largeNumberFormatter.format(activityStats.missed) }}</span>
+            </div>
+            <div flex="~ justify-between" border="t neutral/10" pt-8>
+              <span text-14 text-neutral-700>Miss Rate</span>
+              <span text-14 font-semibold>{{ percentageFormatter.format(activityStats.missRate) }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/composables/useValidatorCharts.ts
+++ b/app/composables/useValidatorCharts.ts
@@ -1,0 +1,107 @@
+import type { Activity, Score } from '~~/server/utils/drizzle'
+
+interface ValidatorData {
+  scores: Score[]
+  activity: Activity[]
+  score?: Score
+  fee: number | null
+  payoutType: string | null
+}
+
+export function useValidatorCharts(validator: Ref<ValidatorData | null>) {
+  const scoreTrendData = computed(() => {
+    if (!validator.value?.scores)
+      return []
+    return validator.value.scores.map(s => ({ epoch: s.epochNumber, total: s.total }))
+  })
+
+  const scoreTrendAllData = computed(() => {
+    if (!validator.value?.scores)
+      return []
+    return validator.value.scores.map(s => ({
+      epoch: s.epochNumber,
+      total: s.total,
+      availability: s.availability,
+      dominance: s.dominance,
+      reliability: s.reliability,
+    }))
+  })
+
+  const balanceData = computed(() => {
+    if (!validator.value?.activity)
+      return []
+    return validator.value.activity.map(a => ({ epoch: a.epochNumber, balance: a.balance / 1e5 }))
+  })
+
+  const stakersData = computed(() => {
+    if (!validator.value?.activity)
+      return []
+    return validator.value.activity.map(a => ({ epoch: a.epochNumber, stakers: a.stakers }))
+  })
+
+  const activityData = computed(() => {
+    if (!validator.value?.activity)
+      return []
+    return validator.value.activity.map(a => ({ epoch: a.epochNumber, rewarded: a.rewarded, missed: a.missed }))
+  })
+
+  const activityStats = computed(() => {
+    if (!validator.value?.activity?.length)
+      return { rewarded: 0, missed: 0, missRate: 0 }
+    const totals = validator.value.activity.reduce((acc, a) => {
+      if (a.rewarded >= 0)
+        acc.rewarded += a.rewarded
+      if (a.missed >= 0)
+        acc.missed += a.missed
+      return acc
+    }, { rewarded: 0, missed: 0 })
+    const total = totals.rewarded + totals.missed
+    return { ...totals, missRate: total > 0 ? totals.missed / total : 0 }
+  })
+
+  const feeDisplay = computed(() => {
+    if (!validator.value || validator.value.fee === null || validator.value.fee < 0)
+      return 'N/A'
+    return percentageFormatter.format(validator.value.fee)
+  })
+
+  const payoutDisplay = computed(() => {
+    if (!validator.value)
+      return 'N/A'
+    const map: Record<string, string> = { restake: 'Restake', direct: 'Direct', none: 'None' }
+    return map[validator.value.payoutType ?? ''] || validator.value.payoutType || 'N/A'
+  })
+
+  const currentBalance = computed(() => {
+    if (!validator.value?.activity?.length)
+      return 0
+    return validator.value.activity.at(-1)!.balance / 1e5
+  })
+
+  const currentStakers = computed(() => {
+    if (!validator.value?.activity?.length)
+      return 0
+    return validator.value.activity.at(-1)!.stakers
+  })
+
+  // Donut data for sub-scores
+  const donutScoreData = computed(() => {
+    if (!validator.value?.score)
+      return [0, 0, 0]
+    return [validator.value.score.availability, validator.value.score.dominance, validator.value.score.reliability]
+  })
+
+  return {
+    scoreTrendData,
+    scoreTrendAllData,
+    balanceData,
+    stakersData,
+    activityData,
+    activityStats,
+    feeDisplay,
+    payoutDisplay,
+    currentBalance,
+    currentStakers,
+    donutScoreData,
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -10,7 +10,7 @@ import { description, name, version } from './package.json'
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   devtools: { enabled: true },
-  modules: ['@vueuse/nuxt', '@unocss/nuxt', '@nuxtjs/color-mode', '@nuxt/eslint', '@nuxthub/core', '@nuxt/image', '@nuxt/fonts', 'reka-ui/nuxt', 'nuxt-safe-runtime-config'],
+  modules: ['@vueuse/nuxt', '@unocss/nuxt', '@nuxtjs/color-mode', '@nuxt/eslint', '@nuxthub/core', '@nuxt/image', '@nuxt/fonts', 'reka-ui/nuxt', 'nuxt-safe-runtime-config', 'nuxt-charts'],
 
   hub: {
     db: 'sqlite',

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "eslint-plugin-format": "catalog:",
     "lint-staged": "catalog:",
     "nimiq-css": "catalog:",
+    "nuxt-charts": "catalog:",
     "nuxt-safe-runtime-config": "catalog:",
     "ofetch": "catalog:",
     "pathe": "catalog:",
@@ -84,6 +85,7 @@
     "vite-plugin-top-level-await": "catalog:",
     "vite-plugin-wasm": "catalog:",
     "vitest": "catalog:",
+    "vue-chrts": "catalog:",
     "vue-tsc": "catalog:",
     "wrangler": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,9 @@ importers:
       nimiq-css:
         specifier: 'catalog:'
         version: 1.0.0-beta.61(@unocss/webpack@66.3.3(webpack@5.100.2(esbuild@0.25.8)))(postcss@8.5.6)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vue@3.5.18(typescript@5.8.3))
+      nuxt-charts:
+        specifier: 2.1.2
+        version: 2.1.2(vue@3.5.18(typescript@5.8.3))
       nuxt-safe-runtime-config:
         specifier: 'catalog:'
         version: 0.1.1(@nuxt/kit@4.3.0(magicast@0.3.5))(@types/json-schema@7.0.15)(eslint@9.31.0(jiti@2.5.0))(quansync@1.0.0)(valibot@1.1.0(typescript@5.8.3))(zod@4.0.8)
@@ -324,6 +327,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      vue-chrts:
+        specifier: ^2.1.2
+        version: 2.1.2(vue@3.5.18(typescript@5.8.3))
       vue-tsc:
         specifier: 'catalog:'
         version: 3.0.3(typescript@5.8.3)
@@ -3002,6 +3008,15 @@ packages:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
 
+  '@turf/boolean-point-in-polygon@7.3.4':
+    resolution: {integrity: sha512-v/4hfyY90Vz9cDgs2GwjQf+Lft8o7mNCLJOTz/iv8SHAIgMMX0czEoIaNVOJr7tBqPqwin1CGwsncrkf5C9n8Q==}
+
+  '@turf/helpers@7.3.4':
+    resolution: {integrity: sha512-U/S5qyqgx3WTvg4twaH0WxF3EixoTCfDsmk98g1E3/5e2YKp7JKYZdz0vivsS5/UZLJeZDEElOSFH4pUgp+l7g==}
+
+  '@turf/invariant@7.3.4':
+    resolution: {integrity: sha512-88Eo4va4rce9sNZs6XiMJowWkikM3cS2TBhaCKlU+GFHdNf8PFEpiU42VDU8q5tOF6/fu21Rvlke5odgOGW4AQ==}
+
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
 
@@ -3013,6 +3028,9 @@ packages:
 
   '@types/d3-array@3.2.1':
     resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
+
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
   '@types/d3-axis@3.0.6':
     resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
@@ -3082,6 +3100,9 @@ packages:
 
   '@types/d3-sankey@0.11.2':
     resolution: {integrity: sha512-U6SrTWUERSlOhnpSrgvMX64WblX1AxX6nEjI2t3mLK2USpQrnbwYYK+AS9SwiE7wgYmOsSSKoSdr8aoKBH0HgQ==}
+
+  '@types/d3-sankey@0.12.5':
+    resolution: {integrity: sha512-/3RZSew0cLAtzGQ+C89hq/Rp3H20QJuVRSqFy6RKLe7E0B8kd2iOS1oBsodrgds4PcNVpqWhdUEng/SHvBcJ6Q==}
 
   '@types/d3-scale-chromatic@3.1.0':
     resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
@@ -3385,10 +3406,19 @@ packages:
   '@unovis/ts@1.5.2':
     resolution: {integrity: sha512-gpg81cr1z/Q9N45wFUkYCGN8o3GbW9U1qx2iQr+xTgyPFoKR9y9+b/savitxzaMGulHAF7cKlm0Nz/pBbQsFoA==}
 
+  '@unovis/ts@1.6.4':
+    resolution: {integrity: sha512-LH8AqYuiVxMcm/SP/VsBKfBa6tu37CJapcn8qeRATZvtYuh8RBDnXr3ejwJyEUvIYJzbPuHOEQo9WIDre9CK1Q==}
+
   '@unovis/vue@1.5.2':
     resolution: {integrity: sha512-NvMJu6dkF5zj7ovop+XTvD/yFBVJMUxQH4AFnYY3BzokvYyxluPnCjQpkResND5I/5ZKpC/LO051oLC9TPo6Jw==}
     peerDependencies:
       '@unovis/ts': 1.5.2
+      vue: ^3
+
+  '@unovis/vue@1.6.4':
+    resolution: {integrity: sha512-Gt5LwmwiMoB0/f1eJL29sfKD9jzlqgTHxc+lW4rMFqIG/PpHLpWL2jTJYVVFfWFd1MjTJWXYiDA06hCEjFcrAg==}
+    peerDependencies:
+      '@unovis/ts': 1.6.4
       vue: ^3
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
@@ -5530,6 +5560,7 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   global-directory@4.0.1:
@@ -6224,6 +6255,9 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  mgrs@1.0.0:
+    resolution: {integrity: sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA==}
+
   micro-api-client@3.3.0:
     resolution: {integrity: sha512-y0y6CUB9RLVsy3kfgayU28746QrNMpSm9O/AYGNsBgOkJr/X/Jk0VLGoO8Ude7Bpa8adywzF+MzXNZRFRsNPhg==}
 
@@ -6607,6 +6641,9 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
+  nuxt-charts@2.1.2:
+    resolution: {integrity: sha512-OJRUQhCz/7BgCclfMHSbXtRXspEng8lYkGE2zxXN0A/Iy9MXP8/6OxxZaSdNybEh5mJ9P/V8oAhYZvuOj0hXkw==}
+
   nuxt-safe-runtime-config@0.1.1:
     resolution: {integrity: sha512-yq88FAVuaLC/CkEA/vbEMjJnhPBQe7bRm0t4WG358MSnSocvmFrMlTQ98oCtQy1Z2aFBr9oAZhdIpOl0uELQgQ==}
     peerDependencies:
@@ -6879,6 +6916,9 @@ packages:
   pnpm-workspace-yaml@1.1.0:
     resolution: {integrity: sha512-OWUzBxtitpyUV0fBYYwLAfWxn3mSzVbVB7cwgNaHvTTU9P0V2QHjyaY5i7f1hEiT9VeKsNH1Skfhe2E3lx/zhA==}
 
+  point-in-polygon-hao@1.2.4:
+    resolution: {integrity: sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==}
+
   postcss-calc@10.1.1:
     resolution: {integrity: sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==}
     engines: {node: ^18.12 || ^20.9 || >=22.0}
@@ -7112,6 +7152,9 @@ packages:
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+
+  proj4@2.20.2:
+    resolution: {integrity: sha512-ipfBRfQly0HhHTO7hnC1GfaX8bvroO7VV4KH889ehmADSE8C/qzp2j+Jj6783S9Tj6c2qX/hhYm7oH0kgXzBAA==}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -7695,6 +7738,7 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   terser-webpack-plugin@5.3.14:
     resolution: {integrity: sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==}
@@ -7882,6 +7926,11 @@ packages:
 
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
+
+  typescript@4.2.4:
+    resolution: {integrity: sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -8391,6 +8440,11 @@ packages:
   vue-bundle-renderer@2.1.1:
     resolution: {integrity: sha512-+qALLI5cQncuetYOXp4yScwYvqh8c6SMXee3B+M7oTZxOgtESP0l4j/fXdEJoZ+EdMxkGWIj+aSEyjXkOdmd7g==}
 
+  vue-chrts@2.1.2:
+    resolution: {integrity: sha512-VH4gGsis2bzuCh2w/v8u2t/HMQnd0cYmqVauRbTvk0+wrbFACwFkkRXvST5M17pAcw8rQAMryoISFAgXiUg4ew==}
+    peerDependencies:
+      vue: ^3.5.13
+
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
     engines: {node: '>=12'}
@@ -8496,6 +8550,9 @@ packages:
   winston@3.17.0:
     resolution: {integrity: sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==}
     engines: {node: '>= 12.0.0'}
+
+  wkt-parser@1.5.2:
+    resolution: {integrity: sha512-1ZUiV1FTwSiSrgWzV9KXJuOF2BVW91KY/mau04BhnmgOdroRQea7Q0s5TVqwGLm0D2tZwObd/tBYXW49sSxp3Q==}
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
@@ -8730,7 +8787,7 @@ snapshots:
 
   '@babel/code-frame@7.27.1':
     dependencies:
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -8817,7 +8874,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.28.0
     transitivePeerDependencies:
       - supports-color
@@ -8909,7 +8966,7 @@ snapshots:
   '@babel/types@7.28.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.28.2':
     dependencies:
@@ -9864,7 +9921,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       node-fetch: 2.7.0
       nopt: 8.1.0
-      semver: 7.7.2
+      semver: 7.7.3
       tar: 7.4.3
     transitivePeerDependencies:
       - encoding
@@ -9979,7 +10036,7 @@ snapshots:
       precinct: 12.2.0
       require-package-name: 2.0.1
       resolve: 2.0.0-next.5
-      semver: 7.7.2
+      semver: 7.7.3
       tmp-promise: 3.0.3
       toml: 3.0.0
       unixify: 1.0.0
@@ -10082,7 +10139,7 @@ snapshots:
       execa: 8.0.1
       magicast: 0.3.5
       pathe: 2.0.3
-      pkg-types: 2.2.0
+      pkg-types: 2.3.0
       prompts: 2.4.2
       semver: 7.7.2
 
@@ -10850,9 +10907,9 @@ snapshots:
       '@rollup/pluginutils': 5.2.0(rollup@4.45.1)
       commondir: 1.0.1
       estree-walker: 2.0.2
-      fdir: 6.4.6(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.3)
       is-reference: 1.2.1
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       picomatch: 4.0.3
     optionalDependencies:
       rollup: 4.45.1
@@ -10861,7 +10918,7 @@ snapshots:
     dependencies:
       '@rollup/pluginutils': 5.2.0(rollup@4.45.1)
       estree-walker: 2.0.2
-      magic-string: 0.30.17
+      magic-string: 0.30.21
     optionalDependencies:
       rollup: 4.45.1
 
@@ -10884,7 +10941,7 @@ snapshots:
   '@rollup/plugin-replace@6.0.2(rollup@4.45.1)':
     dependencies:
       '@rollup/pluginutils': 5.2.0(rollup@4.45.1)
-      magic-string: 0.30.17
+      magic-string: 0.30.21
     optionalDependencies:
       rollup: 4.45.1
 
@@ -11075,6 +11132,25 @@ snapshots:
   '@trysound/sax@0.2.0':
     optional: true
 
+  '@turf/boolean-point-in-polygon@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@turf/invariant': 7.3.4
+      '@types/geojson': 7946.0.16
+      point-in-polygon-hao: 1.2.4
+      tslib: 2.8.1
+
+  '@turf/helpers@7.3.4':
+    dependencies:
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/invariant@7.3.4':
+    dependencies:
+      '@turf/helpers': 7.3.4
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
   '@tybys/wasm-util@0.10.0':
     dependencies:
       tslib: 2.8.1
@@ -11090,6 +11166,8 @@ snapshots:
       '@types/deep-eql': 4.0.2
 
   '@types/d3-array@3.2.1': {}
+
+  '@types/d3-array@3.2.2': {}
 
   '@types/d3-axis@3.0.6':
     dependencies:
@@ -11151,6 +11229,10 @@ snapshots:
   '@types/d3-random@3.0.3': {}
 
   '@types/d3-sankey@0.11.2':
+    dependencies:
+      '@types/d3-shape': 1.3.12
+
+  '@types/d3-sankey@0.12.5':
     dependencies:
       '@types/d3-shape': 1.3.12
 
@@ -11678,9 +11760,87 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@unovis/ts@1.6.4':
+    dependencies:
+      '@emotion/css': 11.13.5
+      '@juggle/resize-observer': 3.4.0
+      '@types/d3': 7.4.3
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-collection': 1.0.13
+      '@types/d3-color': 3.1.3
+      '@types/d3-drag': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-force': 3.0.10
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-sankey': 0.12.5
+      '@types/d3-scale': 4.0.9
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.7
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      '@types/dagre': 0.7.53
+      '@types/geojson': 7946.0.16
+      '@types/leaflet': 1.7.6
+      '@types/supercluster': 5.0.3
+      '@types/three': 0.135.0
+      '@types/throttle-debounce': 5.0.2
+      '@types/topojson': 3.2.6
+      '@types/topojson-client': 3.1.5
+      '@types/topojson-specification': 1.0.5
+      '@unovis/dagre-layout': 0.8.8-2
+      '@unovis/graphlibrary': 2.2.0-2
+      d3: 7.9.0
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-collection: 1.0.7
+      d3-color: 3.1.0
+      d3-drag: 3.0.0
+      d3-ease: 3.0.1
+      d3-force: 3.0.0
+      d3-geo: 3.1.1
+      d3-geo-projection: 4.0.0
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-interpolate-path: 2.3.0
+      d3-path: 3.1.0
+      d3-sankey: 0.12.3
+      d3-scale: 4.0.2
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+      elkjs: 0.10.0
+      geojson: 0.5.0
+      leaflet: 1.7.1
+      maplibre-gl: 2.4.0
+      striptags: 3.2.0
+      supercluster: 7.1.5
+      three: 0.135.0
+      throttle-debounce: 5.0.2
+      topojson-client: 3.1.0
+      tslib: 2.8.1
+      typescript: 4.2.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@unovis/vue@1.5.2(@unovis/ts@1.5.2)(vue@3.5.18(typescript@5.8.3))':
     dependencies:
       '@unovis/ts': 1.5.2
+      vue: 3.5.18(typescript@5.8.3)
+
+  '@unovis/vue@1.6.4(@unovis/ts@1.6.4)(vue@3.5.18(typescript@5.8.3))':
+    dependencies:
+      '@unovis/ts': 1.6.4
       vue: 3.5.18(typescript@5.8.3)
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
@@ -13404,7 +13564,7 @@ snapshots:
   eslint-compat-utils@0.5.1(eslint@9.31.0(jiti@2.5.0)):
     dependencies:
       eslint: 9.31.0(jiti@2.5.0)
-      semver: 7.7.2
+      semver: 7.7.3
 
   eslint-compat-utils@0.6.5(eslint@9.31.0(jiti@2.5.0)):
     dependencies:
@@ -13891,8 +14051,8 @@ snapshots:
 
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
-      magic-string: 0.30.17
-      mlly: 1.7.4
+      magic-string: 0.30.21
+      mlly: 1.8.0
       rollup: 4.45.1
 
   flat-cache@4.0.1:
@@ -14698,7 +14858,7 @@ snapshots:
 
   magic-string-ast@1.0.0:
     dependencies:
-      magic-string: 0.30.17
+      magic-string: 0.30.21
 
   magic-string@0.30.17:
     dependencies:
@@ -14872,6 +15032,8 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  mgrs@1.0.0: {}
 
   micro-api-client@3.3.0: {}
 
@@ -15160,15 +15322,15 @@ snapshots:
       citty: 0.1.6
       cssnano: 7.1.0(postcss@8.5.6)
       defu: 6.1.4
-      esbuild: 0.25.8
+      esbuild: 0.25.12
       jiti: 1.21.7
-      mlly: 1.7.4
+      mlly: 1.8.0
       pathe: 2.0.3
-      pkg-types: 2.2.0
+      pkg-types: 2.3.0
       postcss: 8.5.6
       postcss-nested: 7.0.2(postcss@8.5.6)
-      semver: 7.7.2
-      tinyglobby: 0.2.14
+      semver: 7.7.3
+      tinyglobby: 0.2.15
     optionalDependencies:
       typescript: 5.8.3
       vue: 3.5.18(typescript@5.8.3)
@@ -15363,7 +15525,7 @@ snapshots:
 
   node-abi@3.75.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.7.3
     optional: true
 
   node-addon-api@6.1.0:
@@ -15408,7 +15570,7 @@ snapshots:
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.7.2
+      semver: 7.7.3
       validate-npm-package-license: 3.0.4
 
   normalize-path@2.1.1:
@@ -15431,6 +15593,13 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  nuxt-charts@2.1.2(vue@3.5.18(typescript@5.8.3)):
+    dependencies:
+      vue-chrts: 2.1.2(vue@3.5.18(typescript@5.8.3))
+    transitivePeerDependencies:
+      - supports-color
+      - vue
 
   nuxt-safe-runtime-config@0.1.1(@nuxt/kit@4.3.0(magicast@0.3.5))(@types/json-schema@7.0.15)(eslint@9.31.0(jiti@2.5.0))(quansync@1.0.0)(valibot@1.1.0(typescript@5.8.3))(zod@4.0.8):
     dependencies:
@@ -15864,6 +16033,10 @@ snapshots:
     dependencies:
       yaml: 2.8.0
 
+  point-in-polygon-hao@1.2.4:
+    dependencies:
+      robust-predicates: 3.0.2
+
   postcss-calc@10.1.1(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
@@ -16100,6 +16273,11 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   process@0.11.10: {}
+
+  proj4@2.20.2:
+    dependencies:
+      mgrs: 1.0.0
+      wkt-parser: 1.5.2
 
   prompts@2.4.2:
     dependencies:
@@ -16340,7 +16518,7 @@ snapshots:
 
   rollup-plugin-dts@6.2.1(rollup@4.45.1)(typescript@5.8.3):
     dependencies:
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       rollup: 4.45.1
       typescript: 5.8.3
     optionalDependencies:
@@ -16967,6 +17145,8 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
+  typescript@4.2.4: {}
+
   typescript@5.8.3: {}
 
   ufo@1.6.1: {}
@@ -16986,20 +17166,20 @@ snapshots:
       citty: 0.1.6
       consola: 3.4.2
       defu: 6.1.4
-      esbuild: 0.25.8
+      esbuild: 0.25.12
       fix-dts-default-cjs-exports: 1.0.1
       hookable: 5.5.3
-      jiti: 2.5.0
-      magic-string: 0.30.17
+      jiti: 2.6.1
+      magic-string: 0.30.21
       mkdist: 2.3.0(typescript@5.8.3)(vue-tsc@3.0.3(typescript@5.8.3))(vue@3.5.18(typescript@5.8.3))
-      mlly: 1.7.4
+      mlly: 1.8.0
       pathe: 2.0.3
-      pkg-types: 2.2.0
+      pkg-types: 2.3.0
       pretty-bytes: 7.0.0
       rollup: 4.45.1
       rollup-plugin-dts: 6.2.1(rollup@4.45.1)(typescript@5.8.3)
       scule: 1.3.0
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       untyped: 2.0.0
     optionalDependencies:
       typescript: 5.8.3
@@ -17384,8 +17564,8 @@ snapshots:
   unwasm@0.3.9:
     dependencies:
       knitwork: 1.2.0
-      magic-string: 0.30.17
-      mlly: 1.7.4
+      magic-string: 0.30.21
+      mlly: 1.8.0
       pathe: 1.1.2
       pkg-types: 1.3.1
       unplugin: 1.16.1
@@ -17465,7 +17645,7 @@ snapshots:
       picomatch: 4.0.3
       strip-ansi: 7.1.0
       tiny-invariant: 1.3.3
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       vite: 7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
       vscode-uri: 3.1.0
     optionalDependencies:
@@ -17506,7 +17686,7 @@ snapshots:
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.7
-      magic-string: 0.30.17
+      magic-string: 0.30.21
       pathe: 2.0.3
       source-map-js: 1.2.1
       vite: 7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
@@ -17586,6 +17766,17 @@ snapshots:
   vue-bundle-renderer@2.1.1:
     dependencies:
       ufo: 1.6.1
+
+  vue-chrts@2.1.2(vue@3.5.18(typescript@5.8.3)):
+    dependencies:
+      '@turf/boolean-point-in-polygon': 7.3.4
+      '@unovis/ts': 1.6.4
+      '@unovis/vue': 1.6.4(@unovis/ts@1.6.4)(vue@3.5.18(typescript@5.8.3))
+      d3-geo: 3.1.1
+      proj4: 2.20.2
+      vue: 3.5.18(typescript@5.8.3)
+    transitivePeerDependencies:
+      - supports-color
 
   vue-demi@0.14.10(vue@3.5.18(typescript@5.8.3)):
     dependencies:
@@ -17727,6 +17918,8 @@ snapshots:
       stack-trace: 0.0.10
       triple-beam: 1.4.1
       winston-transport: 4.9.0
+
+  wkt-parser@1.5.2: {}
 
   word-wrap@1.2.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,6 +35,7 @@ catalog:
   nimiq-css: ^1.0.0-beta.61
   nimiq-rpc-client-ts: 1.0.0-beta.28
   nuxt: ^4.0.1
+  nuxt-charts: 2.1.2
   nuxt-safe-runtime-config: ^0.1.1
   ofetch: ^1.4.1
   pathe: ^2.0.3
@@ -51,6 +52,7 @@ catalog:
   vite-plugin-wasm: ^3.5.0
   vitest: ^3.2.4
   vue: ^3.5.18
+  vue-chrts: ^2.1.2
   vue-router: ^4.5.1
   vue-tsc: ^3.0.3
   wrangler: ^4.25.1


### PR DESCRIPTION
## Summary
- Old detail page was minimal (score pie + line chart + raw JSON)
- New page has 3 switchable layouts: Dashboard (stats grid + charts), Deep Dive (score analytics focus), Profile (operator card + 60/40 split)
- Added `nuxt-charts` for AreaChart, BarChart, LineChart, DonutChart, DualChart
- Shared composable `useValidatorCharts` for data transforms

## Test plan
- [ ] `nr dev` → `/validator/<address>` → toggle between 3 layouts
- [ ] View transitions (list → detail → back)
- [ ] Responsive (sm/md breakpoints)
- [ ] Dark mode