### PR TITLE
fix: dev validator import

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@antfu/eslint-config": "catalog:",
     "@antfu/ni": "catalog:",
     "@iconify-json/tabler": "catalog:",
+    "@libsql/client": "catalog:",
     "@nuxt/eslint": "catalog:",
     "@nuxt/fonts": "catalog:",
     "@nuxt/image": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@iconify-json/tabler':
       specifier: ^1.2.20
       version: 1.2.20
+    '@libsql/client':
+      specifier: ^0.17.0
+      version: 0.17.0
     '@nimiq/core':
       specifier: ^2.1.1
       version: 2.1.1
@@ -178,7 +181,7 @@ importers:
         version: 0.12.4
       '@nuxthub/core':
         specifier: 'catalog:'
-        version: 0.10.6(@netlify/blobs@9.1.2)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(ioredis@5.6.1)(magicast@0.3.5)(synckit@0.11.11)(typescript@5.8.3)(vue-tsc@3.0.3(typescript@5.8.3))
+        version: 0.10.6(@netlify/blobs@9.1.2)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(ioredis@5.6.1)(magicast@0.3.5)(synckit@0.11.11)(typescript@5.8.3)(vue-tsc@3.0.3(typescript@5.8.3))
       '@tanstack/vue-table':
         specifier: 'catalog:'
         version: 8.21.3(vue@3.5.18(typescript@5.8.3))
@@ -199,7 +202,7 @@ importers:
         version: 6.1.4
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.44.3(@cloudflare/workers-types@4.20260203.0)
+        version: 0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       identicons-esm:
         specifier: 'catalog:'
         version: 1.0.0-beta.5
@@ -211,7 +214,7 @@ importers:
         version: link:packages/nimiq-validator-trustscore
       nuxt:
         specifier: 'catalog:'
-        version: 4.0.1(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.1.0)(@vue/compiler-sfc@3.5.18)(bufferutil@4.0.9)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0))(eslint@9.31.0(jiti@2.5.0))(ioredis@5.6.1)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup@4.45.1)(terser@5.43.1)(tsx@4.20.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0)
+        version: 4.0.1(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.1.0)(@vue/compiler-sfc@3.5.18)(bufferutil@4.0.9)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(eslint@9.31.0(jiti@2.5.0))(ioredis@5.6.1)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup@4.45.1)(terser@5.43.1)(tsx@4.20.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0)
       reka-ui:
         specifier: 'catalog:'
         version: 2.4.0(typescript@5.8.3)(vue@3.5.18(typescript@5.8.3))
@@ -237,15 +240,18 @@ importers:
       '@iconify-json/tabler':
         specifier: 'catalog:'
         version: 1.2.20
+      '@libsql/client':
+        specifier: 'catalog:'
+        version: 0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@nuxt/eslint':
         specifier: 'catalog:'
         version: 1.7.1(@typescript-eslint/utils@8.38.0(eslint@9.31.0(jiti@2.5.0))(typescript@5.8.3))(@vue/compiler-sfc@3.5.18)(bufferutil@4.0.9)(eslint-plugin-format@1.0.1(eslint@9.31.0(jiti@2.5.0)))(eslint@9.31.0(jiti@2.5.0))(magicast@0.3.5)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@nuxt/fonts':
         specifier: 'catalog:'
-        version: 0.13.0(@netlify/blobs@9.1.2)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(ioredis@5.6.1)(magicast@0.3.5)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+        version: 0.13.0(@netlify/blobs@9.1.2)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(ioredis@5.6.1)(magicast@0.3.5)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@nuxt/image':
         specifier: 'catalog:'
-        version: 1.10.0(@netlify/blobs@9.1.2)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(ioredis@5.6.1)(magicast@0.3.5)
+        version: 1.10.0(@netlify/blobs@9.1.2)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(ioredis@5.6.1)(magicast@0.3.5)
       '@nuxtjs/color-mode':
         specifier: 'catalog:'
         version: 3.5.2(magicast@0.3.5)
@@ -263,7 +269,7 @@ importers:
         version: 66.3.3
       '@vueuse/nuxt':
         specifier: 'catalog:'
-        version: 13.5.0(magicast@0.3.5)(nuxt@4.0.1(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.1.0)(@vue/compiler-sfc@3.5.18)(bufferutil@4.0.9)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0))(eslint@9.31.0(jiti@2.5.0))(ioredis@5.6.1)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup@4.45.1)(terser@5.43.1)(tsx@4.20.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0))(vue@3.5.18(typescript@5.8.3))
+        version: 13.5.0(magicast@0.3.5)(nuxt@4.0.1(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.1.0)(@vue/compiler-sfc@3.5.18)(bufferutil@4.0.9)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(eslint@9.31.0(jiti@2.5.0))(ioredis@5.6.1)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup@4.45.1)(terser@5.43.1)(tsx@4.20.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0))(vue@3.5.18(typescript@5.8.3))
       bumpp:
         specifier: 'catalog:'
         version: 10.2.0(magicast@0.3.5)
@@ -275,7 +281,7 @@ importers:
         version: 0.31.4
       drizzle-zod:
         specifier: 'catalog:'
-        version: 0.8.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0))(zod@4.0.8)
+        version: 0.8.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(zod@4.0.8)
       eslint:
         specifier: 'catalog:'
         version: 9.31.0(jiti@2.5.0)
@@ -1893,6 +1899,63 @@ packages:
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
+  '@libsql/client@0.17.0':
+    resolution: {integrity: sha512-TLjSU9Otdpq0SpKHl1tD1Nc9MKhrsZbCFGot3EbCxRa8m1E5R1mMwoOjKMMM31IyF7fr+hPNHLpYfwbMKNusmg==}
+
+  '@libsql/core@0.17.0':
+    resolution: {integrity: sha512-hnZRnJHiS+nrhHKLGYPoJbc78FE903MSDrFJTbftxo+e52X+E0Y0fHOCVYsKWcg6XgB7BbJYUrz/xEkVTSaipw==}
+
+  '@libsql/darwin-arm64@0.5.22':
+    resolution: {integrity: sha512-4B8ZlX3nIDPndfct7GNe0nI3Yw6ibocEicWdC4fvQbSs/jdq/RC2oCsoJxJ4NzXkvktX70C1J4FcmmoBy069UA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@libsql/darwin-x64@0.5.22':
+    resolution: {integrity: sha512-ny2HYWt6lFSIdNFzUFIJ04uiW6finXfMNJ7wypkAD8Pqdm6nAByO+Fdqu8t7sD0sqJGeUCiOg480icjyQ2/8VA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@libsql/hrana-client@0.9.0':
+    resolution: {integrity: sha512-pxQ1986AuWfPX4oXzBvLwBnfgKDE5OMhAdR/5cZmRaB4Ygz5MecQybvwZupnRz341r2CtFmbk/BhSu7k2Lm+Jw==}
+
+  '@libsql/isomorphic-ws@0.1.5':
+    resolution: {integrity: sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==}
+
+  '@libsql/linux-arm-gnueabihf@0.5.22':
+    resolution: {integrity: sha512-3Uo3SoDPJe/zBnyZKosziRGtszXaEtv57raWrZIahtQDsjxBVjuzYQinCm9LRCJCUT5t2r5Z5nLDPJi2CwZVoA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@libsql/linux-arm-musleabihf@0.5.22':
+    resolution: {integrity: sha512-LCsXh07jvSojTNJptT9CowOzwITznD+YFGGW+1XxUr7fS+7/ydUrpDfsMX7UqTqjm7xG17eq86VkWJgHJfvpNg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@libsql/linux-arm64-gnu@0.5.22':
+    resolution: {integrity: sha512-KSdnOMy88c9mpOFKUEzPskSaF3VLflfSUCBwas/pn1/sV3pEhtMF6H8VUCd2rsedwoukeeCSEONqX7LLnQwRMA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@libsql/linux-arm64-musl@0.5.22':
+    resolution: {integrity: sha512-mCHSMAsDTLK5YH//lcV3eFEgiR23Ym0U9oEvgZA0667gqRZg/2px+7LshDvErEKv2XZ8ixzw3p1IrBzLQHGSsw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@libsql/linux-x64-gnu@0.5.22':
+    resolution: {integrity: sha512-kNBHaIkSg78Y4BqAdgjcR2mBilZXs4HYkAmi58J+4GRwDQZh5fIUWbnQvB9f95DkWUIGVeenqLRFY2pcTmlsew==}
+    cpu: [x64]
+    os: [linux]
+
+  '@libsql/linux-x64-musl@0.5.22':
+    resolution: {integrity: sha512-UZ4Xdxm4pu3pQXjvfJiyCzZop/9j/eA2JjmhMaAhe3EVLH2g11Fy4fwyUp9sT1QJYR1kpc2JLuybPM0kuXv/Tg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@libsql/win32-x64-msvc@0.5.22':
+    resolution: {integrity: sha512-Fj0j8RnBpo43tVZUVoNK6BV/9AtDUM5S7DF3LB4qTYg1LMSZqi3yeCneUTLJD6XomQJlZzbI4mst89yspVSAnA==}
+    cpu: [x64]
+    os: [win32]
+
   '@mapbox/geojson-rewind@0.5.2':
     resolution: {integrity: sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==}
     hasBin: true
@@ -1933,6 +1996,9 @@ packages:
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
+  '@neon-rs/load@0.0.4':
+    resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
   '@netlify/binary-info@1.0.0':
     resolution: {integrity: sha512-4wMPu9iN3/HL97QblBsBay3E1etIciR84izI3U+4iALY+JHCrI+a2jO0qbAZ/nxKoegypYEaiiqWXylm+/zfrw==}
@@ -3207,6 +3273,9 @@ packages:
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
@@ -4283,6 +4352,9 @@ packages:
     resolution: {integrity: sha512-p9nwwR4qyT5W996vBZhdvBCnMhicY5ytZkR4D1Xj0wuTDEiMnjwR57Q3RXYY/s0EpX6Ay3vgIcfaR+ewGHsi+g==}
     engines: {node: '>=18.0'}
 
+  cross-fetch@4.1.0:
+    resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -4618,6 +4690,10 @@ packages:
     resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
     engines: {node: '>=0.10'}
     hasBin: true
+
+  detect-libc@2.0.2:
+    resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
+    engines: {node: '>=8'}
 
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
@@ -5868,6 +5944,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  js-base64@3.7.8:
+    resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -5979,6 +6058,11 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libsql@0.5.22:
+    resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
+    cpu: [x64, arm64, wasm32, arm]
+    os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.31.1:
     resolution: {integrity: sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==}
@@ -7112,6 +7196,9 @@ packages:
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
+
+  promise-limit@2.7.0:
+    resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -9848,6 +9935,68 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
+  '@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@libsql/core': 0.17.0
+      '@libsql/hrana-client': 0.9.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      js-base64: 3.7.8
+      libsql: 0.5.22
+      promise-limit: 2.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
+  '@libsql/core@0.17.0':
+    dependencies:
+      js-base64: 3.7.8
+
+  '@libsql/darwin-arm64@0.5.22':
+    optional: true
+
+  '@libsql/darwin-x64@0.5.22':
+    optional: true
+
+  '@libsql/hrana-client@0.9.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@libsql/isomorphic-ws': 0.1.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      cross-fetch: 4.1.0
+      js-base64: 3.7.8
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
+  '@libsql/isomorphic-ws@0.1.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@types/ws': 8.18.1
+      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/linux-arm-gnueabihf@0.5.22':
+    optional: true
+
+  '@libsql/linux-arm-musleabihf@0.5.22':
+    optional: true
+
+  '@libsql/linux-arm64-gnu@0.5.22':
+    optional: true
+
+  '@libsql/linux-arm64-musl@0.5.22':
+    optional: true
+
+  '@libsql/linux-x64-gnu@0.5.22':
+    optional: true
+
+  '@libsql/linux-x64-musl@0.5.22':
+    optional: true
+
+  '@libsql/win32-x64-msvc@0.5.22':
+    optional: true
+
   '@mapbox/geojson-rewind@0.5.2':
     dependencies:
       get-stream: 6.0.1
@@ -9902,6 +10051,8 @@ snapshots:
       '@emnapi/runtime': 1.8.1
       '@tybys/wasm-util': 0.10.1
     optional: true
+
+  '@neon-rs/load@0.0.4': {}
 
   '@netlify/binary-info@1.0.0': {}
 
@@ -10197,7 +10348,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@nuxt/fonts@0.13.0(@netlify/blobs@9.1.2)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(ioredis@5.6.1)(magicast@0.3.5)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
+  '@nuxt/fonts@0.13.0(@netlify/blobs@9.1.2)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(ioredis@5.6.1)(magicast@0.3.5)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@nuxt/devtools-kit': 3.1.1(magicast@0.3.5)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@nuxt/kit': 4.3.0(magicast@0.3.5)
@@ -10206,7 +10357,7 @@ snapshots:
       defu: 6.1.4
       esbuild: 0.27.2
       fontaine: 0.8.0
-      fontless: 0.1.0(@netlify/blobs@9.1.2)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(ioredis@5.6.1)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      fontless: 0.1.0(@netlify/blobs@9.1.2)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(ioredis@5.6.1)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       h3: 1.15.5
       jiti: 2.6.1
       magic-regexp: 0.10.0
@@ -10219,7 +10370,7 @@ snapshots:
       ufo: 1.6.3
       unifont: 0.6.0
       unplugin: 2.3.11
-      unstorage: 1.17.4(@netlify/blobs@9.1.2)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(ioredis@5.6.1)
+      unstorage: 1.17.4(@netlify/blobs@9.1.2)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(ioredis@5.6.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -10243,7 +10394,7 @@ snapshots:
       - uploadthing
       - vite
 
-  '@nuxt/image@1.10.0(@netlify/blobs@9.1.2)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(ioredis@5.6.1)(magicast@0.3.5)':
+  '@nuxt/image@1.10.0(@netlify/blobs@9.1.2)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(ioredis@5.6.1)(magicast@0.3.5)':
     dependencies:
       '@nuxt/kit': 3.17.7(magicast@0.3.5)
       consola: 3.4.2
@@ -10256,7 +10407,7 @@ snapshots:
       std-env: 3.9.0
       ufo: 1.6.1
     optionalDependencies:
-      ipx: 2.1.0(@netlify/blobs@9.1.2)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(ioredis@5.6.1)
+      ipx: 2.1.0(@netlify/blobs@9.1.2)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(ioredis@5.6.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -10439,7 +10590,7 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxthub/core@0.10.6(@netlify/blobs@9.1.2)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(ioredis@5.6.1)(magicast@0.3.5)(synckit@0.11.11)(typescript@5.8.3)(vue-tsc@3.0.3(typescript@5.8.3))':
+  '@nuxthub/core@0.10.6(@netlify/blobs@9.1.2)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(ioredis@5.6.1)(magicast@0.3.5)(synckit@0.11.11)(typescript@5.8.3)(vue-tsc@3.0.3(typescript@5.8.3))':
     dependencies:
       '@cloudflare/workers-types': 4.20260203.0
       '@nuxt/kit': 4.3.0(magicast@0.3.5)
@@ -10464,7 +10615,7 @@ snapshots:
       tsdown: 0.18.4(synckit@0.11.11)(typescript@5.8.3)(vue-tsc@3.0.3(typescript@5.8.3))
       ufo: 1.6.1
       uncrypto: 0.1.3
-      unstorage: 1.17.4(@netlify/blobs@9.1.2)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(ioredis@5.6.1)
+      unstorage: 1.17.4(@netlify/blobs@9.1.2)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(ioredis@5.6.1)
       zod: 4.3.6
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
@@ -11317,6 +11468,10 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.1.0
+
   '@types/yauzl@2.10.3':
     dependencies:
       '@types/node': 24.1.0
@@ -12003,13 +12158,13 @@ snapshots:
 
   '@vueuse/metadata@13.5.0': {}
 
-  '@vueuse/nuxt@13.5.0(magicast@0.3.5)(nuxt@4.0.1(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.1.0)(@vue/compiler-sfc@3.5.18)(bufferutil@4.0.9)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0))(eslint@9.31.0(jiti@2.5.0))(ioredis@5.6.1)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup@4.45.1)(terser@5.43.1)(tsx@4.20.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0))(vue@3.5.18(typescript@5.8.3))':
+  '@vueuse/nuxt@13.5.0(magicast@0.3.5)(nuxt@4.0.1(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.1.0)(@vue/compiler-sfc@3.5.18)(bufferutil@4.0.9)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(eslint@9.31.0(jiti@2.5.0))(ioredis@5.6.1)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup@4.45.1)(terser@5.43.1)(tsx@4.20.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0))(vue@3.5.18(typescript@5.8.3))':
     dependencies:
       '@nuxt/kit': 3.17.7(magicast@0.3.5)
       '@vueuse/core': 13.5.0(vue@3.5.18(typescript@5.8.3))
       '@vueuse/metadata': 13.5.0
       local-pkg: 1.1.1
-      nuxt: 4.0.1(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.1.0)(@vue/compiler-sfc@3.5.18)(bufferutil@4.0.9)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0))(eslint@9.31.0(jiti@2.5.0))(ioredis@5.6.1)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup@4.45.1)(terser@5.43.1)(tsx@4.20.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0)
+      nuxt: 4.0.1(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.1.0)(@vue/compiler-sfc@3.5.18)(bufferutil@4.0.9)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(eslint@9.31.0(jiti@2.5.0))(ioredis@5.6.1)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup@4.45.1)(terser@5.43.1)(tsx@4.20.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0)
       vue: 3.5.18(typescript@5.8.3)
     transitivePeerDependencies:
       - magicast
@@ -12669,6 +12824,12 @@ snapshots:
 
   croner@9.1.0: {}
 
+  cross-fetch@4.1.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -12950,9 +13111,10 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
-  db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)):
+  db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))):
     optionalDependencies:
-      drizzle-orm: 0.44.3(@cloudflare/workers-types@4.20260203.0)
+      '@libsql/client': 0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      drizzle-orm: 0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
 
   de-indent@1.0.2: {}
 
@@ -13012,6 +13174,8 @@ snapshots:
   destr@2.0.5: {}
 
   detect-libc@1.0.3: {}
+
+  detect-libc@2.0.2: {}
 
   detect-libc@2.0.4: {}
 
@@ -13116,13 +13280,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0):
+  drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260203.0
+      '@libsql/client': 0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
-  drizzle-zod@0.8.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0))(zod@4.0.8):
+  drizzle-zod@0.8.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(zod@4.0.8):
     dependencies:
-      drizzle-orm: 0.44.3(@cloudflare/workers-types@4.20260203.0)
+      drizzle-orm: 0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       zod: 4.0.8
 
   dts-resolver@2.1.3: {}
@@ -13940,7 +14105,7 @@ snapshots:
     dependencies:
       tiny-inflate: 1.0.3
 
-  fontless@0.1.0(@netlify/blobs@9.1.2)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(ioredis@5.6.1)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)):
+  fontless@0.1.0(@netlify/blobs@9.1.2)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(ioredis@5.6.1)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)):
     dependencies:
       consola: 3.4.2
       css-tree: 3.1.0
@@ -13954,7 +14119,7 @@ snapshots:
       pathe: 2.0.3
       ufo: 1.6.3
       unifont: 0.6.0
-      unstorage: 1.17.4(@netlify/blobs@9.1.2)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(ioredis@5.6.1)
+      unstorage: 1.17.4(@netlify/blobs@9.1.2)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(ioredis@5.6.1)
     optionalDependencies:
       vite: 7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
     transitivePeerDependencies:
@@ -14274,7 +14439,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ipx@2.1.0(@netlify/blobs@9.1.2)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(ioredis@5.6.1):
+  ipx@2.1.0(@netlify/blobs@9.1.2)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(ioredis@5.6.1):
     dependencies:
       '@fastify/accept-negotiator': 1.1.0
       citty: 0.1.6
@@ -14290,7 +14455,7 @@ snapshots:
       sharp: 0.32.6
       svgo: 3.3.2
       ufo: 1.6.1
-      unstorage: 1.16.1(@netlify/blobs@9.1.2)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(ioredis@5.6.1)
+      unstorage: 1.16.1(@netlify/blobs@9.1.2)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(ioredis@5.6.1)
       xss: 1.0.15
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -14437,6 +14602,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  js-base64@3.7.8: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -14522,6 +14689,21 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libsql@0.5.22:
+    dependencies:
+      '@neon-rs/load': 0.0.4
+      detect-libc: 2.0.2
+    optionalDependencies:
+      '@libsql/darwin-arm64': 0.5.22
+      '@libsql/darwin-x64': 0.5.22
+      '@libsql/linux-arm-gnueabihf': 0.5.22
+      '@libsql/linux-arm-musleabihf': 0.5.22
+      '@libsql/linux-arm64-gnu': 0.5.22
+      '@libsql/linux-arm64-musl': 0.5.22
+      '@libsql/linux-x64-gnu': 0.5.22
+      '@libsql/linux-x64-musl': 0.5.22
+      '@libsql/win32-x64-msvc': 0.5.22
 
   lightningcss-android-arm64@1.31.1:
     optional: true
@@ -15261,7 +15443,7 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
-  nitropack@2.12.4(@netlify/blobs@9.1.2)(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0))(rolldown@1.0.0-beta.57):
+  nitropack@2.12.4(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@netlify/blobs@9.1.2)(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(rolldown@1.0.0-beta.57):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.0
       '@netlify/functions': 3.1.10(rollup@4.45.1)
@@ -15283,7 +15465,7 @@ snapshots:
       cookie-es: 2.0.0
       croner: 9.1.0
       crossws: 0.3.5
-      db0: 0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0))
+      db0: 0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       defu: 6.1.4
       destr: 2.0.5
       dot-prop: 9.0.0
@@ -15329,7 +15511,7 @@ snapshots:
       unenv: 2.0.0-rc.18
       unimport: 5.2.0
       unplugin-utils: 0.2.4
-      unstorage: 1.16.1(@netlify/blobs@9.1.2)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(ioredis@5.6.1)
+      unstorage: 1.16.1(@netlify/blobs@9.1.2)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(ioredis@5.6.1)
       untyped: 2.0.0
       unwasm: 0.3.9
       youch: 4.1.0-beta.8
@@ -15457,7 +15639,7 @@ snapshots:
       - zod
       - zod-to-json-schema
 
-  nuxt@4.0.1(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.1.0)(@vue/compiler-sfc@3.5.18)(bufferutil@4.0.9)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0))(eslint@9.31.0(jiti@2.5.0))(ioredis@5.6.1)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup@4.45.1)(terser@5.43.1)(tsx@4.20.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0):
+  nuxt@4.0.1(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@netlify/blobs@9.1.2)(@parcel/watcher@2.5.1)(@types/node@24.1.0)(@vue/compiler-sfc@3.5.18)(bufferutil@4.0.9)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(eslint@9.31.0(jiti@2.5.0))(ioredis@5.6.1)(lightningcss@1.31.1)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup@4.45.1)(terser@5.43.1)(tsx@4.20.3)(typescript@5.8.3)(utf-8-validate@5.0.10)(vite@7.0.6(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.31.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))(vue-tsc@3.0.3(typescript@5.8.3))(yaml@2.8.0):
     dependencies:
       '@nuxt/cli': 3.26.4(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
@@ -15492,7 +15674,7 @@ snapshots:
       mlly: 1.7.4
       mocked-exports: 0.1.1
       nanotar: 0.2.0
-      nitropack: 2.12.4(@netlify/blobs@9.1.2)(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0))(rolldown@1.0.0-beta.57)
+      nitropack: 2.12.4(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@netlify/blobs@9.1.2)(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(rolldown@1.0.0-beta.57)
       nypm: 0.6.0
       ofetch: 1.4.1
       ohash: 2.0.11
@@ -15517,7 +15699,7 @@ snapshots:
       unimport: 5.2.0
       unplugin: 2.3.5
       unplugin-vue-router: 0.14.0(@vue/compiler-sfc@3.5.18)(vue-router@4.5.1(vue@3.5.18(typescript@5.8.3)))(vue@3.5.18(typescript@5.8.3))
-      unstorage: 1.16.1(@netlify/blobs@9.1.2)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(ioredis@5.6.1)
+      unstorage: 1.16.1(@netlify/blobs@9.1.2)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(ioredis@5.6.1)
       untyped: 2.0.0
       vue: 3.5.18(typescript@5.8.3)
       vue-bundle-renderer: 2.1.1
@@ -16100,6 +16282,8 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   process@0.11.10: {}
+
+  promise-limit@2.7.0: {}
 
   prompts@2.4.2:
     dependencies:
@@ -17337,7 +17521,7 @@ snapshots:
     optionalDependencies:
       synckit: 0.11.11
 
-  unstorage@1.16.1(@netlify/blobs@9.1.2)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(ioredis@5.6.1):
+  unstorage@1.16.1(@netlify/blobs@9.1.2)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(ioredis@5.6.1):
     dependencies:
       anymatch: 3.1.3
       chokidar: 4.0.3
@@ -17349,10 +17533,10 @@ snapshots:
       ufo: 1.6.1
     optionalDependencies:
       '@netlify/blobs': 9.1.2
-      db0: 0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0))
+      db0: 0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       ioredis: 5.6.1
 
-  unstorage@1.17.4(@netlify/blobs@9.1.2)(db0@0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)))(ioredis@5.6.1):
+  unstorage@1.17.4(@netlify/blobs@9.1.2)(db0@0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))))(ioredis@5.6.1):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -17364,7 +17548,7 @@ snapshots:
       ufo: 1.6.3
     optionalDependencies:
       '@netlify/blobs': 9.1.2
-      db0: 0.3.2(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0))
+      db0: 0.3.2(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(drizzle-orm@0.44.3(@cloudflare/workers-types@4.20260203.0)(@libsql/client@0.17.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       ioredis: 5.6.1
 
   untun@0.1.3:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ catalog:
   '@antfu/eslint-config': ^4.19.0
   '@antfu/ni': ^25.0.0
   '@iconify-json/tabler': ^1.2.20
+  '@libsql/client': ^0.17.0
   '@nimiq/core': ^2.1.1
   '@nimiq/utils': ^0.12.4
   '@nuxt/eslint': ^1.7.1

--- a/server/plugins/setup-database.ts
+++ b/server/plugins/setup-database.ts
@@ -4,15 +4,12 @@ export default defineNitroPlugin(async () => {
   if (!import.meta.dev)
     return
 
-  // Import validators on dev branch
-  hubHooks.hookOnce('database:migrations:done', async () => {
-    const { nimiqNetwork, gitBranch } = useSafeRuntimeConfig().public
-    if (gitBranch !== 'dev')
-      return
+  const { nimiqNetwork } = useSafeRuntimeConfig().public
 
-    const [ok, error, validators] = await importValidatorsBundled(nimiqNetwork)
-    if (!ok)
-      throw new Error(`Error importing validators: ${error}`)
-    consola.success(`${validators.length} validators imported successfully`)
-  })
+  const [ok, error, validators] = await importValidatorsBundled(nimiqNetwork)
+  if (!ok) {
+    consola.warn(`Skipping validator import: ${error}`)
+    return
+  }
+  consola.success(`${validators.length} validators imported successfully`)
 })


### PR DESCRIPTION
## Summary
- Nitro asset storage `getKeys()` doesn't enumerate files in dev mode. Added filesystem fallback.
- Simplified `setup-database.ts`: removed `hookOnce`/migrations gate and `gitBranch` check, warn instead of throw.
- Added `@libsql/client` dependency.