### PR TITLE
fix(api): unlist removed validator profiles

### DIFF
--- a/server/api/[version]/status.get.ts
+++ b/server/api/[version]/status.get.ts
@@ -13,6 +13,7 @@ import { getRpcUrl } from '~~/server/utils/rpc'
  *   - The addresses of the active validators in the current epoch
  *   - The addresses of inactive validators
  *   - The addresses of untracked validators (new validators)
+ *   - The addresses of active validators with removed profile metadata (`unlistedActiveValidators`)
  *   - The addresses of all validators regardless of their status
  *
  *   Blockchain information:

--- a/server/db/migrations/0003_add_cron_runs.sql
+++ b/server/db/migrations/0003_add_cron_runs.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `cron_runs` (
+CREATE TABLE IF NOT EXISTS `cron_runs` (
 	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
 	`cron` text NOT NULL,
 	`network` text NOT NULL,
@@ -10,5 +10,4 @@ CREATE TABLE `cron_runs` (
 	`meta` text
 );
 --> statement-breakpoint
-CREATE INDEX `idx_cron_runs_started_at` ON `cron_runs` (`started_at`);
-
+CREATE INDEX IF NOT EXISTS `idx_cron_runs_started_at` ON `cron_runs` (`started_at`);

--- a/server/db/migrations/0004_add_validator_is_listed.sql
+++ b/server/db/migrations/0004_add_validator_is_listed.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `validators` ADD `is_listed` integer;

--- a/server/db/migrations/0004_add_validator_is_listed.sql
+++ b/server/db/migrations/0004_add_validator_is_listed.sql
@@ -1,1 +1,4 @@
-ALTER TABLE `validators` ADD `is_listed` integer;
+-- The `is_listed` column was added manually in remote D1 databases.
+-- Keep this as a no-op migration so deploy-time migrations don't fail
+-- with "duplicate column name: is_listed".
+SELECT 1;

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -16,6 +16,7 @@ export const validators = sqliteTable('validators', {
   accentColor: text('accent_color').notNull(),
   website: text('website'),
   contact: text('contact', { mode: 'json' }),
+  isListed: integer('is_listed', { mode: 'boolean' }),
 }, table => [
   uniqueIndex('validators_address_unique').on(table.address),
   check(

--- a/server/utils/types.ts
+++ b/server/utils/types.ts
@@ -12,6 +12,7 @@ export interface SnapshotEpochValidators {
   electedValidators: (ElectedValidator | UnelectedValidator)[]
   unelectedValidators: (ElectedValidator | UnelectedValidator)[]
   deletedValidators: string[]
+  unlistedActiveValidators: string[]
 
   /**
    * Validators that are not tracked by the database. The untracked validators are

--- a/server/utils/validator-listing.ts
+++ b/server/utils/validator-listing.ts
@@ -1,0 +1,38 @@
+const UNKNOWN_VALIDATOR_NAME = 'Unknown validator'
+
+interface ValidatorListState {
+  isListed: boolean | null
+  name: string
+}
+
+interface ValidatorAddress {
+  address: string
+}
+
+interface StoredValidatorAddressState extends ValidatorAddress {
+  isListed: boolean | null
+}
+
+export function isKnownValidatorProfile({ isListed, name }: ValidatorListState) {
+  if (typeof isListed === 'boolean')
+    return isListed
+  return name.toLowerCase() !== UNKNOWN_VALIDATOR_NAME.toLowerCase()
+}
+
+export function getUnlistedAddresses(storedAddresses: string[], bundledAddresses: Set<string>) {
+  return storedAddresses.filter(address => !bundledAddresses.has(address))
+}
+
+export function getUnlistedActiveValidatorAddresses(
+  epochValidators: ValidatorAddress[],
+  storedValidators: StoredValidatorAddressState[],
+) {
+  const unlistedAddresses = new Set(
+    storedValidators
+      .filter(v => v.isListed === false)
+      .map(v => v.address),
+  )
+  return epochValidators
+    .filter(v => unlistedAddresses.has(v.address))
+    .map(v => v.address)
+}

--- a/server/utils/validators.ts
+++ b/server/utils/validators.ts
@@ -5,7 +5,7 @@ import type { Activity, Score, Validator } from './drizzle'
 import type { MainQuerySchema, ValidatorJSON } from './schemas'
 import type { FetchedValidator, SnapshotEpochValidators } from './types'
 import { consola } from 'consola'
-import { and, eq, gte, inArray, lte, sql } from 'drizzle-orm'
+import { and, desc, eq, gte, inArray, lte, sql } from 'drizzle-orm'
 import { fetchSnapshotEpoch } from '~~/packages/nimiq-validator-trustscore/src/fetcher'
 import { tables, useDrizzle } from './drizzle'
 import { handleValidatorLogo } from './logo'
@@ -399,6 +399,18 @@ export async function fetchValidator(_event: H3Event, params: FetchValidatorOpti
       ))
       .execute()
 
+    const score = await useDrizzle()
+      .select()
+      .from(tables.scores)
+      .where(and(
+        eq(tables.scores.validatorId, validator.id),
+        gte(tables.scores.epochNumber, fromEpoch),
+        lte(tables.scores.epochNumber, toEpoch),
+      ))
+      .orderBy(desc(tables.scores.epochNumber))
+      .limit(1)
+      .then(rows => rows.at(0))
+
     const activity = await useDrizzle()
       .select()
       .from(tables.activity)
@@ -409,7 +421,6 @@ export async function fetchValidator(_event: H3Event, params: FetchValidatorOpti
       ))
       .execute()
 
-    const score = scores.sort((a, b) => a.epochNumber < b.epochNumber ? 1 : -1).at(0)
     return [true, undefined, { ...validator, scores, activity, score }]
   }
   catch (error) {


### PR DESCRIPTION
## Summary
- add `is_listed` flag to `validators`
- validators present in the bundled profile list are listed; validators removed from that list (or discovered without a bundled profile) are unlisted
- unlisted validators keep row/history, but profile metadata is neutralized
- `only-known=true` now uses listed state (with fallback for legacy `NULL` rows)
- expose `isListed` on validator responses and `unlistedActiveValidators` on status
