### PR TITLE
chore: remove preview environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    environment: preview-testnet
+    environment: testnet
     steps:
       - uses: actions/checkout@v4
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -59,4 +59,4 @@ curl -I https://validators-api-testnet.pages.dev/api/v1/status
 1. Verify Workers fully operational
 2. Deploy redirects to Pages projects
 3. Monitor for 1-2 weeks
-4. (Optional) Deprecate .pages.dev URLs and add custom domain
+4. (Optional) Deprecate legacy `.pages.dev` URLs and add a custom domain

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The Validators API provides endpoints to retrieve validator information for inte
 The Validators Dashboard is a simple Nuxt application that displays all validators along with their scores. You can access the dashboard here: https://validators-api-main.je-cf9.workers.dev/
 
 > [!TIP]
-> Check also the [deployment](#deployment) section to learn how to access to the `testnet` and `preview` environments.
+> Check also the [deployment](#deployment) section to learn how to access the `testnet` environment.
 
 ## How the API works
 
@@ -209,7 +209,7 @@ Deployed via Wrangler CLI with `wrangler.json` config:
 pnpm build && npx wrangler --cwd .output deploy [-e env]
 ```
 
-Where `env`: `preview`, `testnet`, or `testnet-preview` (omit for mainnet production).
+Where `env`: `testnet` (omit `-e env` for mainnet production).
 
 **Required secrets:** `ALBATROSS_RPC_NODE_URL`, `NUXT_SLACK_WEBHOOK_URL`
 
@@ -250,15 +250,13 @@ pnpm db:apply:is-listed:testnet
 **Environments** (configured in `wrangler.json`):
 
 - `production`: [Validators API Mainnet](https://validators-api-main.je-cf9.workers.dev) via manual `wrangler deploy`
-- `preview`: [Validators API Mainnet Preview](https://validators-api-main.je-cf9.workers.dev) via manual deployment
 - `testnet`: [Validators API Testnet](https://validators-api-test.je-cf9.workers.dev) via manual `wrangler deploy --env testnet`
-- `testnet-preview`: [Validators API Testnet Preview](https://validators-api-test.je-cf9.workers.dev) via manual deployment
 
 Each environment has its own D1 database, KV cache, and R2 blob. Sync runs every 12 hours via Cloudflare cron triggers (see `server/tasks/sync/`).
 
 ### Deployment Migration
 
-Migrated from Cloudflare Pages to Workers for cron job support.
+Migrated from Cloudflare Pages to Workers for cron job support. Pages URLs remain legacy redirects only and are not active deployment targets.
 
 **Old URLs (redirect to Workers):**
 

--- a/app/app.vue
+++ b/app/app.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import type { EnvItemType } from './utils/environments'
+import { environments, getEnvironmentItem } from './utils/environments'
+
 const { data: status, status: statusRequest, refresh: refreshStatus, error } = await useFetch('/api/v1/status', { server: true, lazy: false })
 
 const colorMode = useColorMode()
@@ -10,32 +13,18 @@ const isActivitySync = computed(() => Boolean(status.value?.missingEpochs?.lengt
 const isScoreSync = computed(() => status.value?.missingScore === false)
 const isSynced = computed(() => isActivitySync.value && isScoreSync.value)
 
-const { gitBranch, nimiqNetwork } = useSafeRuntimeConfig().public
-
-interface EnvItemType { branch: string, network: string, link: string }
-
-const environments: EnvItemType[] = [
-  { branch: 'main', network: 'main-albatross', link: 'https://validators-api-main.je-cf9.workers.dev/' },
-  { branch: 'main', network: 'test-albatross', link: 'https://validators-api-test.je-cf9.workers.dev/' },
-  { branch: 'dev', network: 'main-albatross', link: 'https://dev.validators-api-mainnet.pages.dev/' },
-  { branch: 'dev', network: 'test-albatross', link: 'https://dev.validators-api-testnet.pages.dev/' },
-
-]
+const { nimiqNetwork } = useSafeRuntimeConfig().public
 const [DefineEnvItem, EnvItem] = createReusableTemplate<{ item: EnvItemType, component: string }>()
 
-const currentEnvItem = { branch: gitBranch, network: nimiqNetwork, link: environments.find(env => env.branch === gitBranch && env.network === nimiqNetwork)?.link || '' }
+const currentEnvItem = getEnvironmentItem(nimiqNetwork) ?? { network: nimiqNetwork, link: '' }
 </script>
 
 <template>
-  <DefineEnvItem v-slot="{ item: { branch, network, link }, component }">
-    <component :is="component" :href="component === 'a' ? link : undefined" flex="~ col gap-2" f-px-2xs :title="`Nimiq network: ${network}.\nGit branch: ${branch}.`">
+  <DefineEnvItem v-slot="{ item: { network, link }, component }">
+    <component :is="component" :href="component === 'a' ? link : undefined" flex="~ col gap-2" f-px-2xs :title="`Nimiq network: ${network}.`">
       <div text="current f-xs" flex="~ gap-4 items-center">
         <div i-nimiq:globe scale-80 text-neutral-600 />
         <span nq-label text="9 neutral-800">{{ network }}</span>
-      </div>
-      <div text="current f-xs" flex="~ gap-4 items-center">
-        <div i-tabler:git-branch text-neutral-600 />
-        <span nq-label text="9 neutral-800">{{ branch }}</span>
       </div>
     </component>
   </DefineEnvItem>
@@ -64,7 +53,7 @@ const currentEnvItem = { branch: gitBranch, network: nimiqNetwork, link: environ
             </CollapsibleContent>
           </CollapsibleRoot>
 
-          <div flex="~ items-center gap-8" f-px-2xs py-6 whitespace-nowrap :title="`Status for git+${gitBranch}@nimiq+${nimiqNetwork}`" :class="statusRequest === 'pending' ? 'bg-neutral-400' : isSynced ? 'bg-green-400' : 'bg-red-400'">
+          <div flex="~ items-center gap-8" f-px-2xs py-6 whitespace-nowrap :title="`Status for nimiq+${nimiqNetwork}`" :class="statusRequest === 'pending' ? 'bg-neutral-400' : isSynced ? 'bg-green-400' : 'bg-red-400'">
             <template v-if="statusRequest === 'pending'">
               <div i-nimiq:spinner />
               Getting health

--- a/app/utils/environments.test.ts
+++ b/app/utils/environments.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { environments, getEnvironmentItem } from './environments'
+
+describe('environments', () => {
+  it('only exposes mainnet and testnet worker deployments', () => {
+    expect(environments).toEqual([
+      { network: 'main-albatross', link: 'https://validators-api-main.je-cf9.workers.dev/' },
+      { network: 'test-albatross', link: 'https://validators-api-test.je-cf9.workers.dev/' },
+    ])
+  })
+
+  it('resolves the current environment by network', () => {
+    expect(getEnvironmentItem('main-albatross')).toEqual({ network: 'main-albatross', link: 'https://validators-api-main.je-cf9.workers.dev/' })
+    expect(getEnvironmentItem('test-albatross')).toEqual({ network: 'test-albatross', link: 'https://validators-api-test.je-cf9.workers.dev/' })
+    expect(getEnvironmentItem('unknown-network')).toBeUndefined()
+  })
+})

--- a/app/utils/environments.ts
+++ b/app/utils/environments.ts
@@ -1,0 +1,13 @@
+export interface EnvItemType {
+  network: string
+  link: string
+}
+
+export const environments: EnvItemType[] = [
+  { network: 'main-albatross', link: 'https://validators-api-main.je-cf9.workers.dev/' },
+  { network: 'test-albatross', link: 'https://validators-api-test.je-cf9.workers.dev/' },
+]
+
+export function getEnvironmentItem(network: string) {
+  return environments.find(env => env.network === network)
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev:packages": "nr -C packages -r dev",
     "build": "pnpm validators:bundle:generate && nr -r build && NODE_OPTIONS=--max-old-space-size=4096 nuxt build",
     "generate": "nuxt generate",
-    "preview": "npx wrangler --cwd .output dev",
+    "worker:dev": "npx wrangler --cwd .output dev",
     "postinstall": "nuxt prepare",
     "prepublishOnly": "nr build",
     "typecheck": "nuxt typecheck && nr -r typecheck",

--- a/wrangler.json
+++ b/wrangler.json
@@ -19,18 +19,6 @@
   "kv_namespaces": [{ "binding": "CACHE", "id": "4be4d10e6d3444eca6e7c02cdbcd275f" }],
   "r2_buckets": [{ "binding": "BLOB", "bucket_name": "validators-api-mainnet" }],
   "env": {
-    "preview": {
-      "name": "validators-api-mainnet-preview",
-      "main": "dist/server/index.mjs",
-      "assets": { "directory": "dist/public" },
-      "compatibility_flags": ["nodejs_compat"],
-      "observability": { "enabled": true, "logs": { "enabled": true, "invocation_logs": true } },
-      "triggers": { "crons": ["0 */12 * * *"] },
-      "vars": { "NUXT_PUBLIC_NIMIQ_NETWORK": "main-albatross" },
-      "d1_databases": [{ "binding": "DB", "database_id": "dd9fa8b7-f5a1-48ab-b0af-d93d1092b89a", "database_name": "validators-api-mainnet-preview" }],
-      "kv_namespaces": [{ "binding": "CACHE", "id": "e3497d0c795d46f59473e187d4d70920" }],
-      "r2_buckets": [{ "binding": "BLOB", "bucket_name": "validators-api-mainnet-preview" }]
-    },
     "testnet": {
       "name": "validators-api-test",
       "main": "dist/server/index.mjs",
@@ -42,18 +30,6 @@
       "d1_databases": [{ "binding": "DB", "database_id": "de14e353-5028-4e52-a383-a9cc200d960d", "database_name": "validators-api-testnet" }],
       "kv_namespaces": [{ "binding": "CACHE", "id": "90c1598af92a4e72a767e6601090f014" }],
       "r2_buckets": [{ "binding": "BLOB", "bucket_name": "validators-api-testnet" }]
-    },
-    "testnet-preview": {
-      "name": "validators-api-testnet-preview",
-      "main": "dist/server/index.mjs",
-      "assets": { "directory": "dist/public" },
-      "compatibility_flags": ["nodejs_compat"],
-      "observability": { "enabled": true, "logs": { "enabled": true, "invocation_logs": true } },
-      "triggers": { "crons": ["0 */12 * * *"] },
-      "vars": { "NUXT_PUBLIC_NIMIQ_NETWORK": "test-albatross" },
-      "d1_databases": [{ "binding": "DB", "database_id": "da6931b2-6d06-4598-911b-fba1fa19efd2", "database_name": "validators-api-testnet-preview" }],
-      "kv_namespaces": [{ "binding": "CACHE", "id": "9ef2ab4420a04df8b5d82825f79620e1" }],
-      "r2_buckets": [{ "binding": "BLOB", "bucket_name": "validators-api-testnet-preview" }]
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove preview Wrangler environments and rename the local worker dev script
- simplify the header environment switcher to mainnet and testnet only
- retarget CI/docs to the two-worker deployment model and add a small environment mapping test

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test